### PR TITLE
Minor changes for test.cpp

### DIFF
--- a/example/test.cpp
+++ b/example/test.cpp
@@ -217,8 +217,8 @@ public:
     keyboard = seat.get_keyboard();
 
     // load cursor theme
-    cursor_theme = cursor_theme_t("redglass", 16, shm);
-    cursor_t cursor = cursor_theme.get_cursor("shuttle");
+    cursor_theme = cursor_theme_t("default", 16, shm);
+    cursor_t cursor = cursor_theme.get_cursor("cross");
     cursor_image_t cursor_image = cursor.image(0);
     cursor_buffer = cursor_image.get_buffer();
 


### PR DESCRIPTION
This pull request contains minor changes. It's better to use the default cursor theme and a general cursor name, because this way the test program won't fail if "redglass" theme isn't installed on the system. Using arrays instead of vectors is only a cosmetic change. I thought it would be nice to use this feature of C++11 here, since the EGL configuration arrays are static, so "array" is semantically better here than "vector".
