### PR TITLE
Allow public access to proxy_t c_ptr() and state

### DIFF
--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -166,9 +166,6 @@ namespace wayland
     // Constructs NULL proxies.
     proxy_t();
 
-    // Get a pointer to the underlying C struct.
-    wl_proxy *c_ptr();
-
   public:
     /** \brief Cronstruct a proxy_t from a wl_proxy pointer
         \param p Pointer to a wl_proxy
@@ -228,6 +225,31 @@ namespace wayland
         See also: display_t::dispatch_queue().
     */
     void set_queue(event_queue_t queue);
+    
+    /** \brief Get a pointer to the underlying C struct.
+     *  \return The underlying wl_proxy wrapped by this proxy_t if it exists,
+     *          otherwise an exception is thrown
+     */
+    wl_proxy *c_ptr();
+    
+    /** \brief Check whether this wrapper actually wraps an object
+     *  \return true if there is an underlying object, false if this wrapper is
+     *          empty
+     */
+    bool proxy_has_object();
+    
+    /** \brief Check whether this wrapper actually wraps an object
+     *  \return true if there is an underlying object, false if this wrapper is
+     *          empty
+     */
+    operator bool();
+    
+    /** \brief Release the wrapped object (if any), making this an empty wrapper
+     * 
+     * Note that display_t instances cannot be released this way. Attempts to
+     * do so are ignored.
+     */
+    void proxy_release();
   };
 
   class callback_t;

--- a/src/wayland-client.cpp
+++ b/src/wayland-client.cpp
@@ -239,6 +239,11 @@ proxy_t &proxy_t::operator=(proxy_t &&p)
 
 proxy_t::~proxy_t()
 {
+  proxy_release();
+}
+
+void proxy_t::proxy_release()
+{
   if(proxy && !display)
     {
       data->counter--;
@@ -252,8 +257,12 @@ proxy_t::~proxy_t()
             }
           delete data;
         }
+  
+      proxy = NULL;
+      data = NULL;
     }
 }
+
 
 uint32_t proxy_t::get_id()
 {
@@ -275,6 +284,16 @@ wl_proxy *proxy_t::c_ptr()
   if(!proxy)
     throw std::invalid_argument("proxy is NULL");
   return proxy;
+}
+
+bool proxy_t::proxy_has_object()
+{
+  return proxy;
+}
+
+proxy_t::operator bool()
+{
+  return proxy_has_object();
 }
 
 display_t::display_t(int fd)


### PR DESCRIPTION
There are valid use cases for clients wanting to use the
underlying wl_proxy* of a proxy_t and there should be no particular
reason to deny them access to it. Also, since the proxy_t knows whether
it currently wraps any object, this should also be made available to
clients. Functionality for explicitly releasing the proxy can also
be useful.
The new functions have the prefix "proxy_" in order to minimize the
chances of name clashes with Wayland interface functions.