### PR TITLE
Add wayland::set_log_handler

### DIFF
--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -39,6 +39,21 @@
 
 namespace wayland
 {
+  /** \brief Type for functions that handle log messages
+   *
+   * Log message is the first argument
+   */
+  typedef std::function<void(std::string)> log_handler;
+  /** \brief Set C library log handler
+   *
+   * The C library sometimes logs important information such as protocol
+   * error messages, by default to the standard output. This can be used
+   * to set an alternate function that will receive those messages.
+   *
+   * \param handler function that should be called for C library log messages
+   */
+  void set_log_handler(log_handler handler);
+
   /** \brief A queue for proxy_t object events. 
     
       Event queues allows the events on a display to be handled in a

--- a/src/wayland-client.cpp
+++ b/src/wayland-client.cpp
@@ -24,12 +24,43 @@
  */
 
 #include <cassert>
+#include <cstdarg>
+#include <cstdio>
 #include <iostream>
 #include <wayland-client.hpp>
 #include <wayland-client-protocol.hpp>
 
 using namespace wayland;
 using namespace wayland::detail;
+
+namespace
+{
+
+log_handler g_log_handler;
+
+extern "C"
+void _c_log_handler(const char *format, va_list args)
+{
+  if(!g_log_handler)
+    return;
+  
+  // Format string
+  va_list args_copy;
+  // vsnprintf consumes args, so copy beforehand
+  va_copy(args_copy, args);
+  std::vector<char> buf(1 + std::vsnprintf(nullptr, 0, format, args));
+  std::vsnprintf(buf.data(), buf.size(), format, args_copy);
+  
+  g_log_handler(buf.data());
+}
+
+}
+
+void wayland::set_log_handler(log_handler handler)
+{
+  g_log_handler = handler;
+  wl_log_set_handler_client(_c_log_handler);
+}
 
 event_queue_t::queue_ptr::~queue_ptr()
 {


### PR DESCRIPTION
C library sometimes logs important information that should also be made available to the C++ code (with some added convenience).