### PR TITLE
Reorganize EGL stuff

### DIFF
--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -33,7 +33,6 @@
 #include <string>
 #include <vector>
 #include <wayland-client-core.h>
-#include <EGL/egl.h>
 #include <wayland-egl.hpp>
 #include <wayland-util.hpp>
 

--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -119,9 +119,7 @@ namespace wayland
     std::function<proxy_t(proxy_t)> copy_constructor;
 
     friend class registry_t;
-    friend class egl_window_t;
     friend class cursor_theme_t;
-    friend EGLDisplay (::eglGetDisplay)(wayland::display_t &display);
 
     // marshal a request, that doesn't lead a new proxy
     // Valid types for args are:
@@ -230,7 +228,7 @@ namespace wayland
      *  \return The underlying wl_proxy wrapped by this proxy_t if it exists,
      *          otherwise an exception is thrown
      */
-    wl_proxy *c_ptr();
+    wl_proxy *c_ptr() const;
     
     /** \brief Check whether this wrapper actually wraps an object
      *  \return true if there is an underlying object, false if this wrapper is
@@ -613,6 +611,8 @@ namespace wayland
         list and bind the global objects available from the compositor.
     */
     registry_t get_registry();
+    
+    operator wl_display*() const;
   };
 }
 

--- a/include/wayland-egl.hpp
+++ b/include/wayland-egl.hpp
@@ -31,13 +31,9 @@
 
 namespace wayland
 {
-  class display_t;
   class surface_t;
 }
 
-// C++ Overrides for EGL functions that depend on native types
-
-EGLDisplay eglGetDisplay(wayland::display_t &display);
 namespace wayland
 {
   /** \brief Native EGL window

--- a/include/wayland-egl.hpp
+++ b/include/wayland-egl.hpp
@@ -31,7 +31,6 @@
 
 namespace wayland
 {
-  class egl_window_t;
   class display_t;
   class surface_t;
 }
@@ -39,10 +38,6 @@ namespace wayland
 // C++ Overrides for EGL functions that depend on native types
 
 EGLDisplay eglGetDisplay(wayland::display_t &display);
-EGLSurface eglCreateWindowSurface(EGLDisplay dpy, EGLConfig config,
-				  wayland::egl_window_t &win,
-				  const EGLint *attrib_list);
-
 namespace wayland
 {
   /** \brief Native EGL window
@@ -54,10 +49,6 @@ namespace wayland
 
     egl_window_t(const egl_window_t &);
 
-    friend EGLSurface (::eglCreateWindowSurface)(EGLDisplay dpy, EGLConfig config,
-                                               wayland::egl_window_t &win,
-                                               const EGLint *attrib_list);
-
   public:
     /** \brief Create a native egl window for use with eglCreateWindowSurface
         \param surface The Wayland surface to use
@@ -66,6 +57,10 @@ namespace wayland
     */
     egl_window_t(surface_t &surface, int width, int height);
     ~egl_window_t();
+    
+    wl_egl_window *c_ptr() const;
+    // This enables support for passing a egl_window_t to eglCreateWindowSurface
+    operator wl_egl_window*() const;
 
     egl_window_t();
     egl_window_t(egl_window_t &&w);

--- a/src/wayland-client.cpp
+++ b/src/wayland-client.cpp
@@ -280,7 +280,7 @@ void proxy_t::set_queue(event_queue_t queue)
   wl_proxy_set_queue(c_ptr(), queue.c_ptr());
 }
 
-wl_proxy *proxy_t::c_ptr()
+wl_proxy *proxy_t::c_ptr() const
 {
   if(!proxy)
     throw std::invalid_argument("proxy is NULL");
@@ -409,4 +409,9 @@ callback_t display_t::sync()
 registry_t display_t::get_registry()
 {
   return registry_t(marshal_constructor(1, &registry_interface, NULL));
+}
+
+display_t::operator wl_display*() const
+{
+  return reinterpret_cast<wl_display*>(c_ptr());
 }

--- a/src/wayland-egl.cpp
+++ b/src/wayland-egl.cpp
@@ -56,6 +56,16 @@ egl_window_t &egl_window_t::operator=(egl_window_t &&w)
   return *this;
 }
 
+wl_egl_window *egl_window_t::c_ptr() const
+{
+  return window;
+}
+
+egl_window_t::operator wl_egl_window*() const
+{
+  return c_ptr();
+}
+
 void egl_window_t::resize(int width, int height, int dx, int dy)
 {
   if(window)
@@ -78,11 +88,4 @@ void egl_window_t::get_attached_size(int &width, int &height)
 EGLDisplay eglGetDisplay(display_t &display)
 {
   return eglGetDisplay(reinterpret_cast<EGLNativeDisplayType>(display.c_ptr()));
-}
-
-EGLSurface eglCreateWindowSurface(EGLDisplay dpy, EGLConfig config,
-				  egl_window_t &win,
-				  const EGLint *attrib_list)
-{
-  return eglCreateWindowSurface(dpy, config, reinterpret_cast<EGLNativeWindowType>(win.window), attrib_list);
 }

--- a/src/wayland-egl.cpp
+++ b/src/wayland-egl.cpp
@@ -23,6 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <stdexcept>
 #include <utility>
 #include <wayland-egl.hpp>
 #include <wayland-client-protocol.hpp>
@@ -32,10 +33,12 @@ using namespace wayland;
 egl_window_t::egl_window_t(surface_t &surface, int width, int height)
 {
   window = wl_egl_window_create(reinterpret_cast<wl_surface*>(surface.c_ptr()), width, height);
+  if(!window)
+    throw std::runtime_error("Failed to create native wl_egl_window");
 }
 
 egl_window_t::egl_window_t()
-  : window(NULL)
+  : window(nullptr)
 {
 }
 

--- a/src/wayland-egl.cpp
+++ b/src/wayland-egl.cpp
@@ -85,10 +85,3 @@ void egl_window_t::get_attached_size(int &width, int &height)
       height = 0;
     }
 }
-
-// C++ Overrides
-
-EGLDisplay eglGetDisplay(display_t &display)
-{
-  return eglGetDisplay(reinterpret_cast<EGLNativeDisplayType>(display.c_ptr()));
-}


### PR DESCRIPTION
Now that `proxy_t` has `c_ptr()` public, it's only natural to add it here, too.

Also, if conversion operators to the native C types are defined, the C++ overloads for eglGetDisplay and eglCreateWindowSurface are not needed at all.

The conversion operators could theoretically be added to all other types, too - what do you think?