### PR TITLE
Fix empty instance creation from proxy

### DIFF
--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -113,10 +113,10 @@ namespace wayland
       unsigned int counter;
     };
 
-    wl_proxy *proxy;
-    proxy_data_t *data;
-    bool display;
-    bool dontdestroy;
+    wl_proxy *proxy = nullptr;
+    proxy_data_t *data = nullptr;
+    bool display = false;
+    bool dontdestroy = false;
     friend class detail::argument_t;
 
     // universal dispatcher
@@ -130,7 +130,7 @@ namespace wayland
 
   protected:
     // Interface desctiption filled in by the each interface class
-    const wl_interface *interface;
+    const wl_interface *interface = nullptr;
     // constructor filled in by the each interface class
     std::function<proxy_t(proxy_t)> copy_constructor;
 

--- a/scanner/scanner.cpp
+++ b/scanner/scanner.cpp
@@ -456,8 +456,11 @@ struct interface_t : public element_t
     ss << name << "_t::" << name << "_t(const proxy_t &p)" << std::endl
        << "  : proxy_t(p)" << std::endl
        << "{" << std::endl
-       << "  set_events(std::shared_ptr<proxy_t::events_base_t>(new events_t), dispatcher);" << std::endl
-       << "  set_destroy_opcode(" << destroy_opcode << ");" << std::endl
+       << "  if(proxy_has_object())" << std::endl
+       << "    {" << std::endl
+       << "      set_events(std::shared_ptr<proxy_t::events_base_t>(new events_t), dispatcher);" << std::endl
+       << "      set_destroy_opcode(" << destroy_opcode << ");" << std::endl
+       << "    }" << std::endl
        << "  interface = &" << name << "_interface;" << std::endl
        << "  copy_constructor = [] (const proxy_t &p) -> proxy_t" << std::endl
        << "    { return " << name << "_t(p); };" << std::endl

--- a/src/wayland-client.cpp
+++ b/src/wayland-client.cpp
@@ -211,12 +211,11 @@ std::shared_ptr<proxy_t::events_base_t> proxy_t::get_events()
 }
 
 proxy_t::proxy_t()
-  : proxy(NULL), data(NULL), display(false), interface(NULL)
 {
 }
 
 proxy_t::proxy_t(wl_proxy *p, bool is_display, bool donotdestroy)
-  : proxy(p), data(NULL), display(is_display), dontdestroy(donotdestroy), interface(NULL)
+  : proxy(p), display(is_display), dontdestroy(donotdestroy)
 {
   if(!display)
     {


### PR DESCRIPTION
waylandpp currently segfaults when the code does this (happens e.g. when dispatching events with NULL objects):
```
wayland::proxy_t proxy;
wayland::surface_t(proxy);
```