### PR TITLE
Unify operators and functions available on wrappers

### DIFF
--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -271,6 +271,13 @@ namespace wayland
      */
     operator bool() const;
     
+    /** \brief Check whether two wrappers refer to the same object
+     */
+    bool operator==(const proxy_t &right) const;
+    /** \brief Check whether two wrappers refer to different objects
+     */    
+    bool operator!=(const proxy_t &right) const;
+    
     /** \brief Release the wrapped object (if any), making this an empty wrapper
      * 
      * Note that display_t instances cannot be released this way. Attempts to

--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -58,23 +58,11 @@ namespace wayland
       Event queues allows the events on a display to be handled in a
       thread-safe manner. See display_t for details.
   */
-  class event_queue_t
+  class event_queue_t : public detail::refcounted_wrapper<wl_event_queue>
   {
   private:
-    struct queue_ptr
-    {
-      wl_event_queue *queue;
-      ~queue_ptr();
-    };
-
-    std::shared_ptr<queue_ptr> queue;
     event_queue_t(wl_event_queue *q);
-
-    friend class proxy_t;
     friend class display_t;
-
-    // Get a pointer to the underlying C struct.
-    wl_event_queue *c_ptr();
   };
 
   class display_t;
@@ -134,8 +122,6 @@ namespace wayland
     std::function<proxy_t(proxy_t)> copy_constructor;
 
     friend class registry_t;
-    friend class cursor_theme_t;
-
     // marshal a request, that doesn't lead a new proxy
     // Valid types for args are:
     // - uint32_t

--- a/include/wayland-cursor.hpp
+++ b/include/wayland-cursor.hpp
@@ -30,15 +30,17 @@
 #include <string>
 #include <wayland-cursor.h>
 #include <wayland-client-protocol.hpp>
+#include <wayland-util.hpp>
 
 namespace wayland
 {
-  class cursor_image_t
+  class cursor_image_t : public detail::basic_wrapper<wl_cursor_image>
   {
   private:
-    wl_cursor_image *cursor_image;
-    cursor_image_t(wl_cursor_image *image);
+    cursor_image_t(wl_cursor_image *image, std::shared_ptr<wl_cursor_theme> const& t);
     friend class cursor_t;
+    // Extend lifetime of wl_cursor_theme
+    std::shared_ptr<wl_cursor_theme> cursor_theme;
 
   public:
     cursor_image_t();
@@ -47,15 +49,17 @@ namespace wayland
     uint32_t hotspot_x();
     uint32_t hotspot_y();
     uint32_t delay();
+    // buffer will be destroyed when cursor_theme is destroyed
     buffer_t get_buffer();
   };
 
-  class cursor_t
+  class cursor_t : public detail::basic_wrapper<wl_cursor>
   {
   private:
-    wl_cursor *cursor;
-    cursor_t(wl_cursor *c);
+    cursor_t(wl_cursor *c, std::shared_ptr<wl_cursor_theme> const& t);
     friend class cursor_theme_t;
+    // Extend lifetime of wl_cursor_theme
+    std::shared_ptr<wl_cursor_theme> cursor_theme;
 
   public:
     cursor_t();
@@ -65,17 +69,8 @@ namespace wayland
     int frame(uint32_t time);
   };
 
-  class cursor_theme_t
+  class cursor_theme_t : public detail::refcounted_wrapper<wl_cursor_theme>
   {
-  private:
-    struct cursor_theme_ptr
-    {
-      wl_cursor_theme *cursor_theme;
-      ~cursor_theme_ptr();
-    };
-
-    std::shared_ptr<cursor_theme_ptr> cursor_theme;
-
   public:
     cursor_theme_t();
     cursor_theme_t(std::string name, int size, shm_t shm);

--- a/include/wayland-egl.hpp
+++ b/include/wayland-egl.hpp
@@ -27,6 +27,7 @@
 #define WAYLAND_EGL_HPP
 
 #include <wayland-egl-core.h>
+#include <wayland-util.hpp>
 #include <EGL/egl.h>
 
 namespace wayland
@@ -38,30 +39,17 @@ namespace wayland
 {
   /** \brief Native EGL window
    */
-  class egl_window_t
+  class egl_window_t : public detail::refcounted_wrapper<wl_egl_window>
   {
-  private:
-    wl_egl_window *window;
-
-    egl_window_t(const egl_window_t &);
-
   public:
+    egl_window_t();
     /** \brief Create a native egl window for use with eglCreateWindowSurface
         \param surface The Wayland surface to use
         \param width Width of the EGL buffer
         \param height height of the EGL buffer
     */
     egl_window_t(surface_t &surface, int width, int height);
-    ~egl_window_t();
     
-    wl_egl_window *c_ptr() const;
-    // This enables support for passing a egl_window_t to eglCreateWindowSurface
-    operator wl_egl_window*() const;
-
-    egl_window_t();
-    egl_window_t(egl_window_t &&w);
-    egl_window_t &operator=(egl_window_t &&w);
-
     void resize(int width, int height, int dx = 0, int dy = 0);
     void get_attached_size(int &width, int &height);
   };

--- a/src/wayland-egl.cpp
+++ b/src/wayland-egl.cpp
@@ -31,57 +31,23 @@
 using namespace wayland;
 
 egl_window_t::egl_window_t(surface_t &surface, int width, int height)
+  : refcounted_wrapper<wl_egl_window>({wl_egl_window_create(surface, width, height),
+                                       wl_egl_window_destroy})
 {
-  window = wl_egl_window_create(reinterpret_cast<wl_surface*>(surface.c_ptr()), width, height);
-  if(!window)
+  if(!has_object())
     throw std::runtime_error("Failed to create native wl_egl_window");
 }
 
 egl_window_t::egl_window_t()
-  : window(nullptr)
 {
-}
-
-egl_window_t::~egl_window_t()
-{
-  if(window)
-    wl_egl_window_destroy(window);
-}
-
-egl_window_t::egl_window_t(egl_window_t &&w)
-{
-  operator=(std::move(w));
-}
-
-egl_window_t &egl_window_t::operator=(egl_window_t &&w)
-{
-  std::swap(window, w.window);
-  return *this;
-}
-
-wl_egl_window *egl_window_t::c_ptr() const
-{
-  return window;
-}
-
-egl_window_t::operator wl_egl_window*() const
-{
-  return c_ptr();
 }
 
 void egl_window_t::resize(int width, int height, int dx, int dy)
 {
-  if(window)
-    wl_egl_window_resize(window, width, height, dx, dy);
+  wl_egl_window_resize(c_ptr(), width, height, dx, dy);
 }
 
 void egl_window_t::get_attached_size(int &width, int &height)
 {
-  if(window)
-    wl_egl_window_get_attached_size(window, &width, &height);
-  else
-    {
-      width = 0;
-      height = 0;
-    }
+  wl_egl_window_get_attached_size(c_ptr(), &width, &height);
 }


### PR DESCRIPTION
The various wrappers that were not based on proxy_t had quite differing operators and functions. Some had move constructors, some not etc. This PR tries to unify things a bit by a common base class.

First commit also adds operator== and operator!= to proxy_t which is important because if not defined the compiler will coerce left and right argument to bool in proxy1==proxy2 comparisons and compare that, which is wrong.