### PR TITLE
Improve thread-safety when copying proxy_t

### DIFF
--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -28,6 +28,7 @@
 
 /** \file */
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <string>
@@ -97,7 +98,7 @@ namespace wayland
     {
       std::shared_ptr<events_base_t> events;
       int opcode; 
-      unsigned int counter;
+      std::atomic<unsigned int> counter;
     };
 
     wl_proxy *proxy = nullptr;

--- a/src/wayland-client.cpp
+++ b/src/wayland-client.cpp
@@ -209,7 +209,7 @@ proxy_t::proxy_t(wl_proxy *p, bool is_display, bool donotdestroy)
       data = reinterpret_cast<proxy_data_t*>(wl_proxy_get_user_data(c_ptr()));
       if(!data)
         {
-          data = new proxy_data_t{std::shared_ptr<events_base_t>(), -1, 0};
+          data = new proxy_data_t{std::shared_ptr<events_base_t>(), -1, {0}};
           wl_proxy_set_user_data(proxy, data);
         }
       data->counter++;
@@ -267,8 +267,7 @@ void proxy_t::proxy_release()
 {
   if(proxy && !display)
     {
-      data->counter--;
-      if(data->counter == 0)
+      if(--data->counter == 0)
         {
           if(!dontdestroy)
             {


### PR DESCRIPTION
`operator++` on unsigned int is by default not atomic, which means
that the refcount on proxy_t could be wrong when copying objects
in multiple threads at the same time. Fix by replacing with std::atomic.