### PR TITLE
Add helpers for checking availability of functions

### DIFF
--- a/example/dump.cpp
+++ b/example/dump.cpp
@@ -64,7 +64,7 @@ public:
           outputs.emplace_back();
           auto& output = outputs.back();
           registry.bind(name, output, version);
-          output.on_geometry() = [&](int32_t x, int32_t y, int32_t physw, int32_t physh, output_subpixel subp, std::string make, std::string model, output_transform transform)
+          output.on_geometry() = [=](int32_t x, int32_t y, int32_t physw, int32_t physh, output_subpixel subp, std::string make, std::string model, output_transform transform)
           {
             std::cout << "* Output geometry for " << output.get_id() << ":" << std::endl
               << "   Maker:   " << make << std::endl
@@ -76,11 +76,11 @@ public:
               << "   Subpix:  " << static_cast<unsigned int>(subp) << std::endl
               << "   Transf:  " << static_cast<unsigned int>(transform) << std::endl;
           };
-          output.on_scale() = [&](int32_t scale)
+          output.on_scale() = [=](int32_t scale)
           {
             std::cout << "* Output scale for " << output.get_id() << ": " << scale << std::endl;
           };
-          output.on_mode() = [&](uint32_t flags, int32_t width, int32_t height, int32_t refresh)
+          output.on_mode() = [=](uint32_t flags, int32_t width, int32_t height, int32_t refresh)
           {
             std::cout << "* Output mode for " << output.get_id() << ":" << std::endl
               << "   Width:   " << width << std::endl

--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -114,7 +114,7 @@ namespace wayland
 
     // marshal request
     proxy_t marshal_single(uint32_t opcode, const wl_interface *interface,
-                           std::vector<detail::argument_t> v);
+                           std::vector<detail::argument_t> v, std::uint32_t version = 0);
 
   protected:
     // Interface desctiption filled in by the each interface class
@@ -137,13 +137,22 @@ namespace wayland
       marshal_single(opcode, NULL, v);
     }
 
-    // marshal a request, that leads a new proxy
+    // marshal a request that leads to a new proxy with inherited version
     template <typename...T>
     proxy_t marshal_constructor(uint32_t opcode, const wl_interface *interface,
                                 T...args)
     {
       std::vector<detail::argument_t> v = { detail::argument_t(args)... };
       return marshal_single(opcode, interface, v);
+    }
+
+    // marshal a request that leads to a new proxy with specific version
+    template <typename...T>
+    proxy_t marshal_constructor_versioned(uint32_t opcode, const wl_interface *interface,
+                                          uint32_t version, T...args)
+    {
+      std::vector<detail::argument_t> v = { detail::argument_t(args)... };
+      return marshal_single(opcode, interface, v, version);
     }
 
     // Set the opcode for destruction of the proxy (-1 unsets it)

--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -134,8 +134,7 @@ namespace wayland
     void marshal(uint32_t opcode, T...args)
     {
       std::vector<detail::argument_t> v = { detail::argument_t(args)... };
-      if(c_ptr())
-        marshal_single(opcode, NULL, v);
+      marshal_single(opcode, NULL, v);
     }
 
     // marshal a request, that leads a new proxy
@@ -144,9 +143,7 @@ namespace wayland
                                 T...args)
     {
       std::vector<detail::argument_t> v = { detail::argument_t(args)... };
-      if(c_ptr())
-        return marshal_single(opcode, interface, v);
-      return proxy_t();
+      return marshal_single(opcode, interface, v);
     }
 
     // Set the opcode for destruction of the proxy (-1 unsets it)

--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -209,12 +209,12 @@ namespace wayland
     /** \brief Get the id of a proxy object.
         \return The id the object associated with the proxy
     */
-    uint32_t get_id();
+    uint32_t get_id() const;
 
     /** \brief Get the interface name (class) of a proxy object. 
         \return The interface name of the object associated with the proxy 
     */
-    std::string get_class();
+    std::string get_class() const;
     
     /** \brief Get the protocol object version of a proxy object.
      * 
@@ -228,7 +228,7 @@ namespace wayland
      * 
      * \return The protocol object version of the proxy or 0
      */
-    uint32_t get_version();
+    uint32_t get_version() const;
 
     /** \brief Assign a proxy to an event queue.
         \param queue The event queue that will handle this proxy 
@@ -302,7 +302,7 @@ namespace wayland
     /** \brief Check whether this intent was already finalized with \ref cancel
      * or \ref read
      */
-    bool is_finalized();
+    bool is_finalized() const;
     /** \brief Cancel read intent
      * 
      * An exception is thrown when the read intent was already finalized.
@@ -604,7 +604,7 @@ namespace wayland
         Note: Errors are fatal. If this function returns non-zero the
         display can no longer be used.
     */
-    int get_error();
+    int get_error() const;
 
     /** \brief Send all buffered requests on the display to the server. 
         \return The number of bytes sent on success or -1 on failure

--- a/scanner/scanner.cpp
+++ b/scanner/scanner.cpp
@@ -262,14 +262,13 @@ struct request_t : public event_t
 
     if(ret.name == "")
       ss <<  "  marshal(" << opcode << ", ";
+    else if(ret.interface == "")
+      {
+        ss << "  proxy_t p = marshal_constructor_versioned(" << opcode << ", interface.interface, version, ";
+      }
     else
       {
-        ss << "  proxy_t p = marshal_constructor(" << opcode << ", ";
-        if(ret.interface == "")
-          ss << "interface.interface";
-        else
-          ss << "&" << ret.interface << "_interface";
-        ss << ", ";
+        ss << "  proxy_t p = marshal_constructor(" << opcode << ", &" << ret.interface << "_interface, ";
       }
 
     for(auto &arg : args)

--- a/src/wayland-client.cpp
+++ b/src/wayland-client.cpp
@@ -152,14 +152,19 @@ int proxy_t::c_dispatcher(const void *implementation, void *target, uint32_t opc
   return dispatcher(opcode, vargs, p.get_events());
 }
 
-proxy_t proxy_t::marshal_single(uint32_t opcode, const wl_interface *interface, std::vector<argument_t> args)
+proxy_t proxy_t::marshal_single(uint32_t opcode, const wl_interface *interface, std::vector<argument_t> args, std::uint32_t version)
 {
   std::vector<wl_argument> v;
   for(auto &arg : args)
     v.push_back(arg.argument);
   if(interface)
     {
-      wl_proxy *p = wl_proxy_marshal_array_constructor(proxy, opcode, v.data(), interface);
+      wl_proxy *p;
+      if(version > 0)
+        p = wl_proxy_marshal_array_constructor_versioned(proxy, opcode, v.data(), interface, version);
+      else
+        p = wl_proxy_marshal_array_constructor(proxy, opcode, v.data(), interface);
+
       if(!p)
         throw std::runtime_error("wl_proxy_marshal_array_constructor");
       wl_proxy_set_user_data(p, NULL); // Wayland leaves the user data uninitialized

--- a/src/wayland-client.cpp
+++ b/src/wayland-client.cpp
@@ -284,17 +284,17 @@ void proxy_t::proxy_release()
 }
 
 
-uint32_t proxy_t::get_id()
+uint32_t proxy_t::get_id() const
 {
   return wl_proxy_get_id(c_ptr());
 }
 
-std::string proxy_t::get_class()
+std::string proxy_t::get_class() const
 {
   return wl_proxy_get_class(c_ptr());
 }
 
-uint32_t proxy_t::get_version()
+uint32_t proxy_t::get_version() const
 {
   return wl_proxy_get_version(c_ptr());
 }
@@ -343,7 +343,7 @@ read_intent::~read_intent()
     cancel();
 }
 
-bool read_intent::is_finalized()
+bool read_intent::is_finalized() const
 {
   return finalized;
 }
@@ -464,7 +464,7 @@ int display_t::dispatch_pending()
   return wl_display_dispatch_pending(reinterpret_cast<wl_display*>(c_ptr()));
 }    
 
-int display_t::get_error()
+int display_t::get_error() const
 {
   return wl_display_get_error(reinterpret_cast<wl_display*>(c_ptr()));
 }    


### PR DESCRIPTION
- Use versioned constructor for objects bound using `registry_t::bind()` so `get_version()` actually returns something
- Add helpers that quickly check whether functions are available with the currently bound version

(this includes changes from #17 because I need the const `get_version`, can rebase if merged)