### PR TITLE
Introduce wrapper for wl_fixed_t

### DIFF
--- a/include/wayland-util.hpp
+++ b/include/wayland-util.hpp
@@ -398,9 +398,14 @@ namespace wayland
       argument_t &operator=(const argument_t &arg);
       ~argument_t();
 
-      // handles integers, file descriptors and fixed point numbers
+      // handles integers and file descriptors
       // (this works, because wl_argument is an union)
       argument_t(uint32_t i);
+
+      argument_t(int32_t i);
+
+      // handles wl_fixed_t
+      argument_t(double f);
 
       // handles strings
       argument_t(std::string s);
@@ -410,6 +415,8 @@ namespace wayland
 
       // handles arrays
       argument_t(array_t a);
+      // handles null objects, for example for new-id arguments
+      argument_t(std::nullptr_t);
     };
   }
 

--- a/scanner/scanner.cpp
+++ b/scanner/scanner.cpp
@@ -66,7 +66,7 @@ struct argument_t : public element_t
     else if(type == "uint")
       return "uint32_t";
     else if(type == "fixed")
-      return "int32_t";
+      return "double";
     else if(type == "string")
       return "std::string";
     else if(type == "object")
@@ -305,7 +305,7 @@ struct request_t : public event_t
           {
             if(arg.interface == "")
               ss << "std::string(interface.interface->name), version, ";
-            ss << "NULL, ";
+            ss << "nullptr, ";
           }
         else if(arg.enum_name != "")
           ss << "static_cast<" << arg.print_enum_wire_type() << ">(" << arg.name + "), ";

--- a/src/wayland-client.cpp
+++ b/src/wayland-client.cpp
@@ -95,12 +95,15 @@ int proxy_t::c_dispatcher(const void *implementation, void *target, uint32_t opc
           // int_32_t
         case 'i':
         case 'h':
-        case 'f':
           a = args[c].i;
           break;
           // uint32_t
         case 'u':
           a = args[c].u;
+          break;
+          // fixed
+        case 'f':
+          a = wl_fixed_to_double(args[c].f);
           break;
           // string
         case 's':
@@ -247,7 +250,6 @@ proxy_t &proxy_t::operator=(const proxy_t& p)
 }
 
 proxy_t::proxy_t(proxy_t &&p)
-  : proxy(NULL), data(NULL), display(false), dontdestroy(NULL), interface(NULL)
 {
   operator=(std::move(p));
 }
@@ -497,12 +499,12 @@ std::tuple<int, bool> display_t::flush()
 
 callback_t display_t::sync()
 {
-  return callback_t(marshal_constructor(0, &callback_interface, NULL));
+  return callback_t(marshal_constructor(0, &callback_interface, nullptr));
 }
 
 registry_t display_t::get_registry()
 {
-  return registry_t(marshal_constructor(1, &registry_interface, NULL));
+  return registry_t(marshal_constructor(1, &registry_interface, nullptr));
 }
 
 display_t::operator wl_display*() const

--- a/src/wayland-util.cpp
+++ b/src/wayland-util.cpp
@@ -101,6 +101,18 @@ argument_t::argument_t(uint32_t i)
   is_array = false;
 }
 
+argument_t::argument_t(int32_t i)
+{
+  argument.i = i;
+  is_array = false;
+}
+
+argument_t::argument_t(double f)
+{
+  argument.f = wl_fixed_from_double(f);
+  is_array = false;
+}
+
 argument_t::argument_t(std::string s)
 {
   argument.s = s.c_str();
@@ -110,6 +122,12 @@ argument_t::argument_t(std::string s)
 argument_t::argument_t(proxy_t p)
 {
   argument.o = reinterpret_cast<wl_object*>(p.proxy);
+  is_array = false;
+}
+
+argument_t::argument_t(std::nullptr_t)
+{
+  argument.n = 0;
   is_array = false;
 }
 


### PR DESCRIPTION
So users do not have to call the C API functions wl_fixed_... directly.
Giving implicit conversion operators means that event handlers can
receive an int or double as they please and it will automatically be
converted correctly.