### PR TITLE
Various fixes

### DIFF
--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -166,7 +166,7 @@ namespace wayland
       new. Will automatically be deleted upon destruction.
     */
     void set_events(std::shared_ptr<events_base_t> events,
-                    int(*dispatcher)(int, std::vector<detail::any>, std::shared_ptr<proxy_t::events_base_t>));
+                    int(*dispatcher)(uint32_t, std::vector<detail::any>, std::shared_ptr<proxy_t::events_base_t>));
 
     // Retrieve the perviously set user data
     std::shared_ptr<events_base_t> get_events();

--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -98,8 +98,9 @@ namespace wayland
     struct proxy_data_t
     {
       std::shared_ptr<events_base_t> events;
-      int opcode; 
-      std::atomic<unsigned int> counter;
+      bool has_destroy_opcode{false};
+      std::uint32_t destroy_opcode{};
+      std::atomic<unsigned int> counter{0};
     };
 
     wl_proxy *proxy = nullptr;
@@ -156,8 +157,8 @@ namespace wayland
       return marshal_single(opcode, interface, v, version);
     }
 
-    // Set the opcode for destruction of the proxy (-1 unsets it)
-    void set_destroy_opcode(int destroy_opcode);
+    // Set the opcode for destruction of the proxy
+    void set_destroy_opcode(uint32_t destroy_opcode);
 
     /*
       Sets the dispatcher and its user data. User data must be an

--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -61,9 +61,10 @@ namespace wayland
   */
   class event_queue_t : public detail::refcounted_wrapper<wl_event_queue>
   {
-  private:
     event_queue_t(wl_event_queue *q);
     friend class display_t;
+  public:
+    event_queue_t();
   };
 
   class display_t;

--- a/include/wayland-util.hpp
+++ b/include/wayland-util.hpp
@@ -389,11 +389,12 @@ namespace wayland
     {
     private:
       bool is_array{false};
+      // Uninitialized argument - only for internal use
+      argument_t();
 
     public:
       wl_argument argument;
 
-      argument_t();
       argument_t(const argument_t &arg);
       argument_t &operator=(const argument_t &arg);
       ~argument_t();

--- a/include/wayland-util.hpp
+++ b/include/wayland-util.hpp
@@ -407,13 +407,8 @@ namespace wayland
       // handles wl_fixed_t
       argument_t(double f);
 
-      // handles strings
-      argument_t(std::string s);
-
-      // handles objects
-      argument_t(proxy_t p);
-
-      // handles arrays
+      argument_t(const std::string &s);
+      argument_t(const proxy_t &p);
       argument_t(array_t a);
       // handles null objects, for example for new-id arguments
       argument_t(std::nullptr_t);

--- a/include/wayland-util.hpp
+++ b/include/wayland-util.hpp
@@ -388,7 +388,7 @@ namespace wayland
     class argument_t
     {
     private:
-      bool is_array;
+      bool is_array{false};
 
     public:
       wl_argument argument;

--- a/include/wayland-util.hpp
+++ b/include/wayland-util.hpp
@@ -398,10 +398,7 @@ namespace wayland
       argument_t &operator=(const argument_t &arg);
       ~argument_t();
 
-      // handles integers and file descriptors
-      // (this works, because wl_argument is an union)
       argument_t(uint32_t i);
-
       argument_t(int32_t i);
 
       // handles wl_fixed_t
@@ -412,6 +409,8 @@ namespace wayland
       argument_t(array_t a);
       // handles null objects, for example for new-id arguments
       argument_t(std::nullptr_t);
+      // handles file descriptors (have same type as signed integers, so extra function)
+      static argument_t fd(int fileno);
     };
   }
 

--- a/include/wayland-util.hpp
+++ b/include/wayland-util.hpp
@@ -426,7 +426,7 @@ namespace wayland
     wl_array a;
 
     array_t(wl_array *arr);
-    void get(wl_array *arr);
+    void get(wl_array *arr) const;
 
     friend class proxy_t;
     friend class detail::argument_t;
@@ -462,7 +462,7 @@ namespace wayland
       return *this;
     }
 
-    template <typename T> operator std::vector<T>()
+    template <typename T> operator std::vector<T>() const
     {
       std::vector<T> v;
       T *p;

--- a/scanner/scanner.cpp
+++ b/scanner/scanner.cpp
@@ -506,9 +506,10 @@ struct interface_t : public element_t
        << "{" << std::endl
        << "  if(proxy_has_object())" << std::endl
        << "    {" << std::endl
-       << "      set_events(std::shared_ptr<proxy_t::events_base_t>(new events_t), dispatcher);" << std::endl
-       << "      set_destroy_opcode(" << destroy_opcode << ");" << std::endl
-       << "    }" << std::endl
+       << "      set_events(std::shared_ptr<proxy_t::events_base_t>(new events_t), dispatcher);" << std::endl;
+    if (destroy_opcode != -1)
+      ss << "     set_destroy_opcode(" << destroy_opcode << "u);" << std::endl;
+    ss << "    }" << std::endl
        << "  interface = &" << name << "_interface;" << std::endl
        << "  copy_constructor = [] (const proxy_t &p) -> proxy_t" << std::endl
        << "    { return " << name << "_t(p); };" << std::endl

--- a/scanner/scanner.cpp
+++ b/scanner/scanner.cpp
@@ -833,7 +833,7 @@ int main(int argc, char *argv[])
                   if(entry.attribute("summary"))
                     enum_entry.summary = entry.attribute("summary").value();
 
-                  uint32_t tmp = std::floor(std::log2(stol(enum_entry.value, nullptr, 0)))+1;
+                  uint32_t tmp = static_cast<uint32_t> (std::log2(stol(enum_entry.value, nullptr, 0))) + 1u;
                   if(tmp > enu.width)
                     enu.width = tmp;
 

--- a/scanner/scanner.cpp
+++ b/scanner/scanner.cpp
@@ -27,7 +27,7 @@
 
 using namespace pugi;
 
-std::list<std::string> interface_names;
+static std::list<std::string> interface_names;
 
 struct element_t
 {

--- a/scanner/scanner.cpp
+++ b/scanner/scanner.cpp
@@ -289,14 +289,14 @@ struct request_t : public event_t
     ss << ")\n{" << std::endl;
 
     if(ret.name == "")
-      ss <<  "  marshal(" << opcode << ", ";
+      ss <<  "  marshal(" << opcode << "u, ";
     else if(ret.interface == "")
       {
-        ss << "  proxy_t p = marshal_constructor_versioned(" << opcode << ", interface.interface, version, ";
+        ss << "  proxy_t p = marshal_constructor_versioned(" << opcode << "u, interface.interface, version, ";
       }
     else
       {
-        ss << "  proxy_t p = marshal_constructor(" << opcode << ", &" << ret.interface << "_interface, ";
+        ss << "  proxy_t p = marshal_constructor(" << opcode << "u, &" << ret.interface << "_interface, ";
       }
 
     for(auto &arg : args)
@@ -463,7 +463,7 @@ struct interface_t : public element_t
 
     ss << "  };" << std::endl
        << std::endl
-       << "  static int dispatcher(int opcode, std::vector<detail::any> args, std::shared_ptr<proxy_t::events_base_t> e);" << std::endl
+       << "  static int dispatcher(uint32_t opcode, std::vector<detail::any> args, std::shared_ptr<proxy_t::events_base_t> e);" << std::endl
        << std::endl;
 
     ss << "public:" << std::endl
@@ -538,7 +538,7 @@ struct interface_t : public element_t
     for(auto &event : events)
       ss << event.print_signal_body(name) << std::endl;
 
-    ss << "int " << name << "_t::dispatcher(int opcode, std::vector<any> args, std::shared_ptr<proxy_t::events_base_t> e)" << std::endl
+    ss << "int " << name << "_t::dispatcher(uint32_t opcode, std::vector<any> args, std::shared_ptr<proxy_t::events_base_t> e)" << std::endl
        << "{" << std::endl;
 
     if(events.size())

--- a/scanner/scanner.cpp
+++ b/scanner/scanner.cpp
@@ -307,6 +307,8 @@ struct request_t : public event_t
               ss << "std::string(interface.interface->name), version, ";
             ss << "nullptr, ";
           }
+        else if(arg.type == "fd")
+          ss << "argument_t::fd(" << arg.name << "), ";
         else if(arg.enum_name != "")
           ss << "static_cast<" << arg.print_enum_wire_type() << ">(" << arg.name + "), ";
         else

--- a/scanner/scanner.cpp
+++ b/scanner/scanner.cpp
@@ -513,15 +513,15 @@ struct interface_t : public element_t
       ss << "     set_destroy_opcode(" << destroy_opcode << "u);" << std::endl;
     ss << "    }" << std::endl
        << "  interface = &" << name << "_interface;" << std::endl
-       << "  copy_constructor = [] (const proxy_t &p) -> proxy_t" << std::endl
-       << "    { return " << name << "_t(p); };" << std::endl
+       << "  copy_constructor = [] (const proxy_t &copy_p) -> proxy_t" << std::endl
+       << "    { return " << name << "_t(copy_p); };" << std::endl
        << "}" << std::endl
        << std::endl
        << name << "_t::" << name << "_t()" << std::endl
        << "{" << std::endl
        << "  interface = &" << name << "_interface;" << std::endl
-       << "  copy_constructor = [] (const proxy_t &p) -> proxy_t" << std::endl
-       << "    { return " << name << "_t(p); };" << std::endl
+       << "  copy_constructor = [] (const proxy_t &copy_p) -> proxy_t" << std::endl
+       << "    { return " << name << "_t(copy_p); };" << std::endl
        << "}" << std::endl
        << std::endl
        << "const std::string " << name << "_t::interface_name = \"" << orig_name << "\";" << std::endl

--- a/src/wayland-client.cpp
+++ b/src/wayland-client.cpp
@@ -111,12 +111,15 @@ int proxy_t::c_dispatcher(const void *implementation, void *target, uint32_t opc
         {
           // int_32_t
         case 'i':
-        case 'h':
           a = args[c].i;
           break;
           // uint32_t
         case 'u':
           a = args[c].u;
+          break;
+          // fd
+        case 'h':
+          a = args[c].h;
           break;
           // fixed
         case 'f':

--- a/src/wayland-client.cpp
+++ b/src/wayland-client.cpp
@@ -154,7 +154,7 @@ int proxy_t::c_dispatcher(const void *implementation, void *target, uint32_t opc
       c++;
     }
   proxy_t p(reinterpret_cast<wl_proxy*>(target), false);
-  typedef int(*dispatcher_func)(int, std::vector<any>, std::shared_ptr<proxy_t::events_base_t>);
+  typedef int(*dispatcher_func)(std::uint32_t, std::vector<any>, std::shared_ptr<proxy_t::events_base_t>);
   dispatcher_func dispatcher = reinterpret_cast<dispatcher_func>(const_cast<void*>(implementation));
   return dispatcher(opcode, vargs, p.get_events());
 }
@@ -189,7 +189,7 @@ void proxy_t::set_destroy_opcode(uint32_t destroy_opcode)
 }
 
 void proxy_t::set_events(std::shared_ptr<events_base_t> events,
-                         int(*dispatcher)(int, std::vector<any>, std::shared_ptr<proxy_t::events_base_t>))
+                         int(*dispatcher)(uint32_t, std::vector<any>, std::shared_ptr<proxy_t::events_base_t>))
 {
   // set only one time
   if(!display && !data->events)

--- a/src/wayland-client.cpp
+++ b/src/wayland-client.cpp
@@ -28,7 +28,6 @@
 #include <cstdio>
 #include <cerrno>
 
-#include <iostream>
 #include <limits>
 #include <system_error>
 #include <wayland-client.hpp>
@@ -149,7 +148,6 @@ int proxy_t::c_dispatcher(const void *implementation, void *target, uint32_t opc
             else
               {
                 a = proxy_t();
-                std::cerr << "New id is empty." << std::endl;
               }
           }
           break;

--- a/src/wayland-client.cpp
+++ b/src/wayland-client.cpp
@@ -181,12 +181,11 @@ proxy_t proxy_t::marshal_single(uint32_t opcode, const wl_interface *interface, 
   return proxy_t();
 }
 
-void proxy_t::set_destroy_opcode(int destroy_opcode)
+void proxy_t::set_destroy_opcode(uint32_t destroy_opcode)
 {
-  if(!display)
-    data->opcode = destroy_opcode;
-  else
-    std::cerr << "Not setting destroy opcode on display.";
+  assert(!display);
+  data->has_destroy_opcode = true;
+  data->destroy_opcode = destroy_opcode;
 }
 
 void proxy_t::set_events(std::shared_ptr<events_base_t> events,
@@ -221,7 +220,7 @@ proxy_t::proxy_t(wl_proxy *p, bool is_display, bool donotdestroy)
       data = reinterpret_cast<proxy_data_t*>(wl_proxy_get_user_data(c_ptr()));
       if(!data)
         {
-          data = new proxy_data_t{std::shared_ptr<events_base_t>(), -1, {0}};
+          data = new proxy_data_t;
           wl_proxy_set_user_data(proxy, data);
         }
       data->counter++;
@@ -282,8 +281,8 @@ void proxy_t::proxy_release()
         {
           if(!dontdestroy)
             {
-              if(data->opcode >= 0)
-                wl_proxy_marshal(proxy, data->opcode);
+              if(data->has_destroy_opcode)
+                wl_proxy_marshal(proxy, data->destroy_opcode);
               wl_proxy_destroy(proxy);
             }
           delete data;

--- a/src/wayland-client.cpp
+++ b/src/wayland-client.cpp
@@ -65,6 +65,10 @@ void wayland::set_log_handler(log_handler handler)
   wl_log_set_handler_client(_c_log_handler);
 }
 
+event_queue_t::event_queue_t()
+{
+}
+
 event_queue_t::event_queue_t(wl_event_queue *q)
   : detail::refcounted_wrapper<wl_event_queue>({q, wl_event_queue_destroy})
 {

--- a/src/wayland-util.cpp
+++ b/src/wayland-util.cpp
@@ -51,12 +51,6 @@ namespace wayland
   }
 }
 
-argument_t::argument_t()
-{
-  argument.a = NULL;
-  is_array = false;
-}
-
 argument_t::argument_t(const argument_t &arg)
 {
   operator=(arg);
@@ -83,6 +77,10 @@ argument_t &argument_t::operator=(const argument_t &arg)
   is_array = arg.is_array;
 
   return *this;
+}
+
+argument_t::argument_t()
+{
 }
 
 argument_t::~argument_t()

--- a/src/wayland-util.cpp
+++ b/src/wayland-util.cpp
@@ -144,10 +144,10 @@ array_t::array_t(wl_array *arr)
   wl_array_copy(&a, arr);
 }
 
-void array_t::get(wl_array *arr)
+void array_t::get(wl_array *arr) const
 {
   wl_array_init(arr);
-  wl_array_copy(arr, &a);
+  wl_array_copy(arr, const_cast<wl_array*>(&a));
 }
 
 array_t::array_t()

--- a/src/wayland-util.cpp
+++ b/src/wayland-util.cpp
@@ -64,6 +64,8 @@ argument_t &argument_t::operator=(const argument_t &arg)
       delete argument.a;
     }
 
+  is_array = arg.is_array;
+
   if(arg.is_array)
     {
       argument.a = new wl_array;
@@ -73,8 +75,6 @@ argument_t &argument_t::operator=(const argument_t &arg)
     }
   else
     argument = arg.argument;
-
-  is_array = arg.is_array;
 
   return *this;
 }

--- a/src/wayland-util.cpp
+++ b/src/wayland-util.cpp
@@ -58,8 +58,6 @@ argument_t::argument_t()
 
 argument_t::argument_t(const argument_t &arg)
 {
-  argument.a = NULL;
-  is_array = false;
   operator=(arg);
 }
 
@@ -98,37 +96,31 @@ argument_t::~argument_t()
 argument_t::argument_t(uint32_t i)
 {
   argument.u = i;
-  is_array = false;
 }
 
 argument_t::argument_t(int32_t i)
 {
   argument.i = i;
-  is_array = false;
 }
 
 argument_t::argument_t(double f)
 {
   argument.f = wl_fixed_from_double(f);
-  is_array = false;
 }
 
 argument_t::argument_t(std::string s)
 {
   argument.s = s.c_str();
-  is_array = false;
 }
 
 argument_t::argument_t(proxy_t p)
 {
   argument.o = reinterpret_cast<wl_object*>(p.proxy);
-  is_array = false;
 }
 
 argument_t::argument_t(std::nullptr_t)
 {
   argument.n = 0;
-  is_array = false;
 }
 
 argument_t::argument_t(array_t a)

--- a/src/wayland-util.cpp
+++ b/src/wayland-util.cpp
@@ -27,6 +27,7 @@
 #include <wayland-util.hpp>
 
 #include <cerrno>
+#include <limits>
 #include <system_error>
 
 using namespace wayland;
@@ -128,6 +129,15 @@ argument_t::argument_t(array_t a)
   argument.a = new wl_array;
   a.get(argument.a);
   is_array = true;
+}
+
+argument_t argument_t::fd(int fileno)
+{
+  if (fileno > std::numeric_limits<int32_t>::max())
+    throw std::invalid_argument("FD number too big");
+  argument_t arg;
+  arg.argument.h = static_cast<int32_t> (fileno);
+  return arg;
 }
 
 array_t::array_t(wl_array *arr)

--- a/src/wayland-util.cpp
+++ b/src/wayland-util.cpp
@@ -108,12 +108,12 @@ argument_t::argument_t(double f)
   argument.f = wl_fixed_from_double(f);
 }
 
-argument_t::argument_t(std::string s)
+argument_t::argument_t(const std::string &s)
 {
   argument.s = s.c_str();
 }
 
-argument_t::argument_t(proxy_t p)
+argument_t::argument_t(const proxy_t& p)
 {
   argument.o = reinterpret_cast<wl_object*>(p.proxy);
 }


### PR DESCRIPTION
These are various fixes that fix warnings from clang and correct reliance on implementation-defined behavior (accessing union members that were not most recently written)