### PR TITLE
Fix handling of objects that are owned by other libraries

### DIFF
--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -106,7 +106,7 @@ namespace wayland
     wl_proxy *proxy = nullptr;
     proxy_data_t *data = nullptr;
     bool display = false;
-    bool dontdestroy = false;
+    bool foreign = false;
     friend class detail::argument_t;
 
     // universal dispatcher
@@ -178,8 +178,11 @@ namespace wayland
     /** \brief Cronstruct a proxy_t from a wl_proxy pointer
         \param p Pointer to a wl_proxy
         \param is_display True, if p is a wl_display pointer
+        \param foreign True, if p is owned by another library and should neither
+                       get a dispatcher nor be destroyed when this wrapper goes
+                       out of scope
     */
-    proxy_t(wl_proxy *p, bool is_display = false, bool donotdestroy = false);
+    proxy_t(wl_proxy *p, bool is_display = false, bool foreign = false);
 
     /** \brief Copy Constructior
         \param p A proxy_t object


### PR DESCRIPTION
Some objects (most notably: buffers from libwayland-cursor) are created
in other libraries and we just wrap them so they can be used as
arguments.

Previously, they would have the special parameter dontdestroy set so
that they would not be destroyed if the waylandpp proxy goes out of
scope since the library that owns them would get into trouble then.

But this is not enough: If the waylandpp proxy is destroyed and events
happen after that, the original library will not get them since we
have added our dispatcher. And worse than that, our dispatcher will
crash since the C++ wrapper does not exist any more.

So to fix this, change "dontdestroy" to proper "foreign": If foreign is
set, it means that another library is responsible and we should neither
add our dispatcher nor destroy the object nor set any user data.