### PR TITLE
Add support for proxy wrappers

### DIFF
--- a/example/SConstruct
+++ b/example/SConstruct
@@ -17,3 +17,5 @@ env.Program("shm", "shm.cpp",
                     "rt"])
 env.Program("dump", "dump.cpp",
             LIBS = ["wayland-client++"])
+env.Program("proxy_wrapper", "proxy_wrapper.cpp",
+            LIBS = ["wayland-client++", "pthread"])

--- a/example/proxy_wrapper.cpp
+++ b/example/proxy_wrapper.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2017, Philipp Kerling
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** \example proxy-wrapper.cpp
+ * This is an example of how to use the Wayland C++ bindings with multiple threads
+ * binding to globals on one shared connection using proxy wrappers.
+ *
+ * It can run in two modes: safe or unsafe mode. In safe mode, proxy wrappers
+ * are correctly used. In unsafe mode, proxy wrappers are not used, and a
+ * race occurs that will lead to failures when ran often enough.
+ */
+
+#include <iostream>
+#include <thread>
+#include <unistd.h>
+
+#include <wayland-client.hpp>
+
+using namespace wayland;
+
+class binder
+{
+private:
+  display_t display;
+
+  void bind(bool safe)
+  {
+    registry_t registry;
+    seat_t seat;
+
+    auto queue = display.create_queue();
+    if(safe)
+    {
+      auto display_wrapper = display.proxy_create_wrapper();
+      display_wrapper.set_queue(queue);
+      registry = display_wrapper.get_registry();
+    }
+    else
+    {
+      registry = display.get_registry();
+      // This is the race: registry will be set to the default queue for a very
+      // short while between get_registry() and set_queue() - events dispatched
+      // in between get stuck in the default queue and ultimately lost.
+      registry.set_queue(queue);
+    }
+
+    registry.on_global() = [&seat, &registry](std::uint32_t name, std::string interface, std::uint32_t version)
+    {
+      if(interface == seat_t::interface_name)
+        registry.bind(name, seat, version);
+    };
+    display.roundtrip_queue(queue);
+    if(!seat)
+    {
+      throw std::runtime_error("Did NOT get seat interface - thread-safety issue!");
+    }
+    else
+    {
+      // Now pretend that again another part of the application wants to use the
+      // seat and get the keyboard from it
+      // Note that it would not be necessary to do this in this example, but
+      // this code is useful for testing proxy wrappers with normal interface
+      // objects (display_t is special)
+      auto queue2 = display.create_queue();
+      if(safe)
+      {
+        seat = seat.proxy_create_wrapper();
+      }
+      seat.set_queue(queue2);
+      keyboard_t kbd = seat.get_keyboard();
+      bool have_keymap = false;
+      kbd.on_keymap() = [&have_keymap](keyboard_keymap_format format, int fd, std::uint32_t size)
+      {
+        close(fd);
+        have_keymap = true;
+      };
+      display.roundtrip_queue(queue2);
+      if(!have_keymap)
+      {
+        throw std::runtime_error("Did NOT get keymap - thread-safety issue!");
+      }
+    }
+  }
+
+  std::thread bind_thread(bool safe)
+  {
+    return std::thread{std::bind(&binder::bind, this, safe)};
+  }
+
+public:
+  void run(int thread_count, int round_count, bool safe)
+  {
+    std::atomic<bool> stop{false};
+    std::cout << "Using " << thread_count << " threads, safe: " << safe << std::endl;
+    for(int round = 0; round < round_count; round++)
+    {
+      if(round % 100 == 0)
+      {
+        std::cout << "Round " << round << "/" << round_count << std::endl;
+      }
+      std::vector<std::thread> threads;
+      for(int i = 0; i < thread_count; i++)
+      {
+        threads.emplace_back(bind_thread(safe));
+      }
+      for(auto& thread : threads)
+      {
+        thread.join();
+      }
+    }
+    stop = true;
+  }
+};
+
+int main(int argc, char** argv)
+{
+  if(argc != 4)
+  {
+    std::cerr << "Usage: " << argv[0] << " <thread count> <run count> <use safe mechanism?>" << std::endl;
+    return -1;
+  }
+  binder b;
+  b.run(std::stoi(argv[1]), std::stoi(argv[2]), std::stoi(argv[3]));
+  return 0;
+}

--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -68,6 +68,15 @@ namespace wayland
   };
 
   class display_t;
+  namespace detail
+  {
+    struct proxy_data_t;
+    // base class for event listener storage.
+    struct events_base_t
+    {
+      virtual ~events_base_t() { }
+    };
+  }
 
   /** \brief Represents a protocol object on the client side.
 
@@ -86,28 +95,17 @@ namespace wayland
   */
   class proxy_t
   {
-  protected:
-    // base class for event listener storage.
-    struct events_base_t
     {
       virtual ~events_base_t() { }
     };
 
   private:
-    // stored in the proxy user data
-    struct proxy_data_t
-    {
-      std::shared_ptr<events_base_t> events;
-      bool has_destroy_opcode{false};
-      std::uint32_t destroy_opcode{};
-      std::atomic<unsigned int> counter{0};
-    };
-
     wl_proxy *proxy = nullptr;
-    proxy_data_t *data = nullptr;
     bool display = false;
     bool foreign = false;
+    detail::proxy_data_t *data = nullptr;
     friend class detail::argument_t;
+    friend struct detail::proxy_data_t;
 
     // universal dispatcher
     static int c_dispatcher(const void *implementation, void *target,
@@ -165,11 +163,11 @@ namespace wayland
       instance of a class derived from events_base_t, allocated with
       new. Will automatically be deleted upon destruction.
     */
-    void set_events(std::shared_ptr<events_base_t> events,
-                    int(*dispatcher)(uint32_t, std::vector<detail::any>, std::shared_ptr<proxy_t::events_base_t>));
+    void set_events(std::shared_ptr<detail::events_base_t> events,
+                    int(*dispatcher)(uint32_t, std::vector<detail::any>, std::shared_ptr<detail::events_base_t>));
 
-    // Retrieve the perviously set user data
-    std::shared_ptr<events_base_t> get_events();
+    // Retrieve the previously set user data
+    std::shared_ptr<detail::events_base_t> get_events();
 
     // Constructs NULL proxies.
     proxy_t();

--- a/scanner/scanner.cpp
+++ b/scanner/scanner.cpp
@@ -457,7 +457,7 @@ struct interface_t : public element_t
     ss << "class " << name << "_t : public proxy_t" << std::endl
        << "{" << std::endl
        << "private:" << std::endl
-       << "  struct events_t : public proxy_t::events_base_t" << std::endl
+       << "  struct events_t : public detail::events_base_t" << std::endl
        << "  {" << std::endl;
 
     for(auto &event : events)
@@ -465,7 +465,7 @@ struct interface_t : public element_t
 
     ss << "  };" << std::endl
        << std::endl
-       << "  static int dispatcher(uint32_t opcode, std::vector<detail::any> args, std::shared_ptr<proxy_t::events_base_t> e);" << std::endl
+       << "  static int dispatcher(uint32_t opcode, std::vector<detail::any> args, std::shared_ptr<detail::events_base_t> e);" << std::endl
        << std::endl;
 
     ss << "public:" << std::endl
@@ -508,7 +508,7 @@ struct interface_t : public element_t
        << "{" << std::endl
        << "  if(proxy_has_object())" << std::endl
        << "    {" << std::endl
-       << "      set_events(std::shared_ptr<proxy_t::events_base_t>(new events_t), dispatcher);" << std::endl;
+       << "      set_events(std::shared_ptr<detail::events_base_t>(new events_t), dispatcher);" << std::endl;
     if(destroy_opcode != -1)
       ss << "     set_destroy_opcode(" << destroy_opcode << "u);" << std::endl;
     ss << "    }" << std::endl
@@ -540,7 +540,7 @@ struct interface_t : public element_t
     for(auto &event : events)
       ss << event.print_signal_body(name) << std::endl;
 
-    ss << "int " << name << "_t::dispatcher(uint32_t opcode, std::vector<any> args, std::shared_ptr<proxy_t::events_base_t> e)" << std::endl
+    ss << "int " << name << "_t::dispatcher(uint32_t opcode, std::vector<any> args, std::shared_ptr<detail::events_base_t> e)" << std::endl
        << "{" << std::endl;
 
     if(events.size())

--- a/src/wayland-client.cpp
+++ b/src/wayland-client.cpp
@@ -79,6 +79,7 @@ struct wayland::detail::proxy_data_t
   bool has_destroy_opcode{false};
   std::uint32_t destroy_opcode{};
   std::atomic<unsigned int> counter{1};
+  event_queue_t queue;
 };
 
 void wayland::set_log_handler(log_handler handler)
@@ -338,6 +339,8 @@ uint32_t proxy_t::get_version() const
 
 void proxy_t::set_queue(event_queue_t queue)
 {
+  if (data)
+    data->queue = queue;
   wl_proxy_set_queue(c_ptr(), queue ? queue.c_ptr() : nullptr);
 }
 

--- a/src/wayland-client.cpp
+++ b/src/wayland-client.cpp
@@ -228,7 +228,7 @@ void proxy_t::set_events(std::shared_ptr<events_base_t> events,
   if(data && !data->events)
     {
       data->events = events;
-      // the dispatcher gets 'implemetation'
+      // the dispatcher gets 'implementation'
       if(wl_proxy_add_dispatcher(c_ptr(), c_dispatcher, reinterpret_cast<void*>(dispatcher), data) < 0)
         throw std::runtime_error("wl_proxy_add_dispatcher failed.");
     }

--- a/src/wayland-cursor.cpp
+++ b/src/wayland-cursor.cpp
@@ -121,5 +121,5 @@ buffer_t cursor_image_t::get_buffer()
   wl_proxy *proxy = reinterpret_cast<wl_proxy*>(buffer);
   wl_proxy_set_user_data(proxy, nullptr);
   // buffer will be destroyed when cursor_theme is destroyed
-  return buffer_t(proxy_t(proxy, false, true));
+  return buffer_t(proxy_t(proxy, proxy_t::wrapper_type::foreign));
 }

--- a/src/wayland-cursor.cpp
+++ b/src/wayland-cursor.cpp
@@ -118,8 +118,6 @@ uint32_t cursor_image_t::delay()
 buffer_t cursor_image_t::get_buffer()
 {
   wl_buffer *buffer = wl_cursor_image_get_buffer(c_ptr());
-  wl_proxy *proxy = reinterpret_cast<wl_proxy*>(buffer);
-  wl_proxy_set_user_data(proxy, nullptr);
   // buffer will be destroyed when cursor_theme is destroyed
-  return buffer_t(proxy_t(proxy, proxy_t::wrapper_type::foreign));
+  return buffer_t(buffer, proxy_t::wrapper_type::foreign);
 }


### PR DESCRIPTION
One of the last features of libwayland-client that waylandpp does not support are proxy wrappers - so this PR adds them.

Proxy wrappers are necessary when multiple threads share one Wayland connection, as can easily be the case in multi-threaded Wayland clients. There is a demo program included that shows that not using proxy wrappers for e.g. getting globals will result in failure.

To test the failure, I use `./proxy_wrapper 15 100000 0` which fails after some 10000 iterations, but as usual for races ymmv.