### PR TITLE
create proper shared library version symlink chain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,8 @@ if(BUILD_LIBRARIES)
     target_link_libraries("${TARGET}" ${LDFLAGS})
     set_target_properties("${TARGET}" PROPERTIES
       PUBLIC_HEADER "${HEADERS}"
-      SOVERSION "${WAYLANDPP_VERSION}")
+      VERSION "${WAYLANDPP_VERSION}"
+      SOVERSION "${WAYLANDPP_VERSION_MAJOR}")
     configure_file("${TARGET}.pc.in" "${TARGET}.pc" @ONLY)
     set_target_properties("${TARGET}" PROPERTIES RESOURCE "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.pc")
   endfunction()


### PR DESCRIPTION
Set the correct soname header in libraries so programs don't link to the fully versioned shared library.

creates the following symlink chain:
libwayland-client++.so -> libwayland-client++.so.[major] -> libwayland-client++.so.[full_version]

Fixes having to recompile downstream projects whenever even only a patch version is bumped,
