### PR TITLE
Do not include extension protocols in generated header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,11 +60,7 @@ if(BUILD_LIBRARIES)
   pkg_check_modules(WAYLAND_CURSOR REQUIRED wayland-cursor)
 
   # generate protocol source/headers from protocol XMLs
-  set(PROTO_XMLS
-    "${CMAKE_SOURCE_DIR}/protocols/wayland.xml"
-    "${CMAKE_SOURCE_DIR}/protocols/presentation-time.xml"
-    "${CMAKE_SOURCE_DIR}/protocols/viewporter.xml"
-    "${CMAKE_SOURCE_DIR}/protocols/xdg-shell.xml")
+  set(PROTO_XMLS "${CMAKE_SOURCE_DIR}/protocols/wayland.xml")
   set(PROTO_FILES
     "wayland-client-protocol.hpp"
     "wayland-client-protocol.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ find_package(Doxygen)
 
 # version information
 set(WAYLANDPP_VERSION_MAJOR 0)
-set(WAYLANDPP_VERSION_MINOR 1)
-set(WAYLANDPP_VERSION_PATCH 6)
+set(WAYLANDPP_VERSION_MINOR 2)
+set(WAYLANDPP_VERSION_PATCH 0)
 set(WAYLANDPP_VERSION "${WAYLANDPP_VERSION_MAJOR}.${WAYLANDPP_VERSION_MINOR}.${WAYLANDPP_VERSION_PATCH}")
 configure_file(include/wayland-version.hpp.in wayland-version.hpp @ONLY)
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -6,11 +6,22 @@ pkg_check_modules(EGL REQUIRED egl)
 find_library(LIBRT rt)
 mark_as_advanced(LIBRT)
 
+# protocols
+set(PROTO_XMLS "${CMAKE_SOURCE_DIR}/protocols/xdg-shell.xml")
+set(PROTO_FILES
+  "wayland-extra-client-protocol.hpp"
+  "wayland-extra-client-protocol.cpp")
+add_custom_command(
+  OUTPUT ${PROTO_FILES}
+  COMMAND "${WAYLAND_SCANNERPP}" ${PROTO_XMLS} ${PROTO_FILES}
+  DEPENDS "${WAYLAND_SCANNERPP}" ${PROTO_XMLS})
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+
 # examples
 add_executable(dump dump.cpp)
 target_link_libraries(dump wayland-client++)
 
-add_executable(egl egl.cpp)
+add_executable(egl egl.cpp wayland-extra-client-protocol.cpp)
 target_link_libraries(egl wayland-client++ wayland-cursor++ wayland-egl++ "${OPENGL_gl_LIBRARY}" ${EGL_LDFLAGS})
 target_include_directories(egl PUBLIC "${OPENGL_INCLUDE_DIR}")
 target_compile_options(egl PUBLIC ${EGL_CFLAGS})
@@ -18,7 +29,7 @@ target_compile_options(egl PUBLIC ${EGL_CFLAGS})
 add_executable(proxy_wrapper proxy_wrapper.cpp)
 target_link_libraries(proxy_wrapper wayland-client++ Threads::Threads)
 
-add_executable(shm shm.cpp)
+add_executable(shm shm.cpp wayland-extra-client-protocol.cpp)
 target_link_libraries(shm wayland-client++ wayland-cursor++)
 if(LIBRT)
   target_link_libraries(shm "${LIBRT}")

--- a/example/egl.cpp
+++ b/example/egl.cpp
@@ -31,6 +31,7 @@
 #include <iostream>
 #include <array>
 #include <wayland-client.hpp>
+#include "wayland-extra-client-protocol.hpp"
 #include <wayland-egl.hpp>
 #include <GL/gl.h>
 #include <linux/input.h>

--- a/example/shm.cpp
+++ b/example/shm.cpp
@@ -36,6 +36,7 @@
 #include <algorithm>
 
 #include <wayland-client.hpp>
+#include "wayland-extra-client-protocol.hpp"
 #include <linux/input.h>
 #include <wayland-cursor.hpp>
 


### PR DESCRIPTION
I think it is fine that you distribute some protocol files with waylandpp, but they should not be included in the `wayland-client-protocol.hpp` header. Including them there makes it impossible to use newer versions of the protocol in an application without updating the waylandpp library because the symbols clash. In C libwayland, the protocols in `wayland-protocols` are not distributed as part of `libwayland-client` and it should be the same here.