### PR TITLE
Fix compilation on OpenSUSE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ if(BUILD_LIBRARIES)
   define_library(wayland-client++ "${WAYLAND_CLIENT_CFLAGS}" "${WAYLAND_CLIENT_LDFLAGS}"
     "include/wayland-client.hpp;include/wayland-util.hpp;${CMAKE_CURRENT_BINARY_DIR}/wayland-client-protocol.hpp;${CMAKE_CURRENT_BINARY_DIR}/wayland-version.hpp"
     src/wayland-client.cpp src/wayland-util.cpp wayland-client-protocol.cpp wayland-client-protocol.hpp)
-  define_library(wayland-client-extra++ "${WAYLAND_CLIENT_EXTRA_CFLAGS}" "${WAYLAND_CLIENT_EXTRA_LDFLAGS}"
+  define_library(wayland-client-extra++ "${WAYLAND_CLIENT_CFLAGS}" "${WAYLAND_CLIENT_LDFLAGS}"
     "${CMAKE_CURRENT_BINARY_DIR}/wayland-client-protocol-extra.hpp"
     wayland-client-protocol-extra.cpp wayland-client-protocol-extra.hpp wayland-client-protocol.hpp)
   define_library(wayland-egl++ "${WAYLAND_EGL_CFLAGS}" "${WAYLAND_EGL_LDFLAGS}" include/wayland-egl.hpp src/wayland-egl.cpp wayland-client-protocol.hpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(Doxygen)
 # version information
 set(WAYLANDPP_VERSION_MAJOR 0)
 set(WAYLANDPP_VERSION_MINOR 2)
-set(WAYLANDPP_VERSION_PATCH 2)
+set(WAYLANDPP_VERSION_PATCH 3)
 set(WAYLANDPP_VERSION "${WAYLANDPP_VERSION_MAJOR}.${WAYLANDPP_VERSION_MINOR}.${WAYLANDPP_VERSION_PATCH}")
 configure_file(include/wayland-version.hpp.in wayland-version.hpp @ONLY)
 


### PR DESCRIPTION
wayland-client-extra++ uses nonexistant cflags/libs. This causes an issue on OpenSUSE where wayland headers are installed to `/usr/include/wayland` (different from pretty much all other distributions) and son compilation without the correct cflags does not work.

See https://github.com/hudokkow/xbmc/pull/2#issuecomment-382131123