### PR TITLE
Add missing ${PROTO_FILES_EXTRA} dependency to ${PROTO_FILES_UNSTABLE}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ if(BUILD_LIBRARIES)
   add_custom_command(
     OUTPUT ${PROTO_FILES_UNSTABLE}
     COMMAND "${WAYLAND_SCANNERPP}" ${PROTO_XMLS_UNSTABLE} ${PROTO_FILES_UNSTABLE} "-x" "wayland-client-protocol-extra.hpp"
-    DEPENDS "${WAYLAND_SCANNERPP}" ${PROTO_XMLS_UNSTABLE})
+    DEPENDS "${WAYLAND_SCANNERPP}" ${PROTO_XMLS_UNSTABLE} ${PROTO_FILES_EXTRA})
 
   # library building helper functions
   function(define_library TARGET CFLAGS LDFLAGS HEADERS)


### PR DESCRIPTION
It currently sometimes fails to build on FreeBSD. This seems to fix it.

```
[ 72%] Building CXX object CMakeFiles/wayland-client-unstable++.dir/wayland-client-protocol-unstable.cpp.o
/usr/bin/c++  -Dwayland_client_unstable___EXPORTS -I/wrkdirs/usr/ports/graphics/waylandpp/work/waylandpp-0.2.4/include -I/wrkdirs/usr/ports/graphics/waylandpp/work/.build -O2 -pipe -fstack-protector -fno-strict-aliasing -O2 -pipe -fstack-protector -fno-strict-aliasing -fPIC   -I/usr/local/include -std=gnu++11 -o CMakeFiles/wayland-client-unstable++.dir/wayland-client-protocol-unstable.cpp.o -c /wrkdirs/usr/ports/graphics/waylandpp/work/.build/wayland-client-protocol-unstable.cpp
In file included from /wrkdirs/usr/ports/graphics/waylandpp/work/.build/wayland-client-protocol-unstable.cpp:1:
/wrkdirs/usr/ports/graphics/waylandpp/work/.build/wayland-client-protocol-unstable.hpp:10:10: fatal error: 'wayland-client-protocol-extra.hpp' file not found
 #include <wayland-client-protocol-extra.hpp>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```