### PR TITLE
link to current libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,11 +131,15 @@ if(BUILD_LIBRARIES)
   define_library(wayland-client-extra++ "${WAYLAND_CLIENT_CFLAGS}" "${WAYLAND_CLIENT_LDFLAGS}"
     "${CMAKE_CURRENT_BINARY_DIR}/wayland-client-protocol-extra.hpp"
     wayland-client-protocol-extra.cpp wayland-client-protocol-extra.hpp wayland-client-protocol.hpp)
+  target_link_libraries(wayland-client-extra++ wayland-client++)
   define_library(wayland-client-unstable++ "${WAYLAND_CLIENT_CFLAGS}" "${WAYLAND_CLIENT_LDFLAGS}"
     "${CMAKE_CURRENT_BINARY_DIR}/wayland-client-protocol-unstable.hpp"
     wayland-client-protocol-unstable.cpp wayland-client-protocol-unstable.hpp wayland-client-protocol.hpp)
+  target_link_libraries(wayland-client-unstable++ wayland-client-extra++)
   define_library(wayland-egl++ "${WAYLAND_EGL_CFLAGS}" "${WAYLAND_EGL_LDFLAGS}" include/wayland-egl.hpp src/wayland-egl.cpp wayland-client-protocol.hpp)
+  target_link_libraries(wayland-egl++ wayland-client++)
   define_library(wayland-cursor++ "${WAYLAND_CURSOR_CFLAGS}" "${WAYLAND_CURSOR_LDFLAGS}" include/wayland-cursor.hpp src/wayland-cursor.cpp wayland-client-protocol.hpp)
+  target_link_libraries(wayland-cursor++ wayland-client++)
 
   # Install libraries
   install(FILES ${PROTO_XMLS} ${PROTO_XMLS_EXTRA} ${PROTO_XMLS_UNSTABLE} DESTINATION "${INSTALL_FULL_PKGDATADIR}/protocols")


### PR DESCRIPTION
Some of the libraries need to link to the just built libraries of the
project, instead of stale versions that may exist in the system.

Since the helper function define_library does not support additional
arguments due to the usage of ARGN, append the required
target_link_libraries call to make cmake aware of the build dependency.

Signed-off-by: Olaf Hering <olaf@aepfle.de>