### PR TITLE
include path the foreign header files in pkgconfig

### DIFF
--- a/wayland-client++.pc.in
+++ b/wayland-client++.pc.in
@@ -32,6 +32,6 @@ Name: Wayland C++ Client
 Description: Wayland C++ client side library
 Version: @WAYLANDPP_VERSION@
 URL: https://github.com/NilsBrause/waylandpp
-Requires: wayland-client
+Requires.private: wayland-client
 Cflags: -I${includedir}
 Libs: -L${libdir} -lwayland-client++

--- a/wayland-cursor++.pc.in
+++ b/wayland-cursor++.pc.in
@@ -32,6 +32,6 @@ Name: Wayland C++ Cursor Helper
 Description: Wayland C++ cursor helper library
 Version: @WAYLANDPP_VERSION@
 URL: https://github.com/NilsBrause/waylandpp
-Requires: wayland-cursor wayland-client++
+Requires.private: wayland-cursor wayland-client++
 Cflags: -I${includedir}
 Libs: -L${libdir} -lwayland-cursor++

--- a/wayland-egl++.pc.in
+++ b/wayland-egl++.pc.in
@@ -32,6 +32,6 @@ Name: Wayland C++ EGL helper
 Description: Mesa C++ egl helper library
 Version: @WAYLANDPP_VERSION@
 URL: https://github.com/NilsBrause/waylandpp
-Requires: wayland-egl wayland-client++
+Requires.private: egl wayland-egl wayland-client++
 Cflags: -I${includedir}
 Libs: -L${libdir} -lwayland-egl++


### PR DESCRIPTION
The exported header files require headers from foreign packages
Show their required cflags in pkgconfig --cflags output so that
consumers of our pkgconfig files get the all the required options.

Signed-off-by: Olaf Hering <olaf@aepfle.de>