### PR TITLE
Set expected cmake version before project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-project(waylandpp)
 cmake_minimum_required(VERSION 3.1)
+project(waylandpp)
 
 # packages
 include(FindPkgConfig)


### PR DESCRIPTION
The documentation of cmake 3.3 and later suggests to call
cmake_minimum_required() before project().

This change does not fix any issue I have encountered. It is supposed to
be a cosmetic change to follow documentation of project() usage.

Signed-off-by: Olaf Hering <olaf@aepfle.de>