### PR TITLE
[fix] add missing stdexcept include after 2d834a6

### DIFF
--- a/include/wayland-util.hpp
+++ b/include/wayland-util.hpp
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <typeinfo>
 #include <utility>


### PR DESCRIPTION
fixes `error: ‘runtime_error’ is not a member of ‘std’`