### PR TITLE
Update wayland protocols

### DIFF
--- a/protocols/extra/presentation-time.xml
+++ b/protocols/extra/presentation-time.xml
@@ -159,43 +159,43 @@
         These flags provide information about how the presentation of
         the related content update was done. The intent is to help
         clients assess the reliability of the feedback and the visual
-        quality with respect to possible tearing and timings. The
-        flags are:
-
-        VSYNC:
-        The presentation was synchronized to the "vertical retrace" by
-        the display hardware such that tearing does not happen.
-        Relying on user space scheduling is not acceptable for this
-        flag. If presentation is done by a copy to the active
-        frontbuffer, then it must guarantee that tearing cannot
-        happen.
-
-        HW_CLOCK:
-        The display hardware provided measurements that the hardware
-        driver converted into a presentation timestamp. Sampling a
-        clock in user space is not acceptable for this flag.
-
-        HW_COMPLETION:
-        The display hardware signalled that it started using the new
-        image content. The opposite of this is e.g. a timer being used
-        to guess when the display hardware has switched to the new
-        image content.
-
-        ZERO_COPY:
-        The presentation of this update was done zero-copy. This means
-        the buffer from the client was given to display hardware as
-        is, without copying it. Compositing with OpenGL counts as
-        copying, even if textured directly from the client buffer.
-        Possible zero-copy cases include direct scanout of a
-        fullscreen surface and a surface on a hardware overlay.
+        quality with respect to possible tearing and timings.
       </description>
-      <entry name="vsync" value="0x1" summary="presentation was vsync'd"/>
-      <entry name="hw_clock" value="0x2"
-             summary="hardware provided the presentation timestamp"/>
-      <entry name="hw_completion" value="0x4"
-             summary="hardware signalled the start of the presentation"/>
-      <entry name="zero_copy" value="0x8"
-             summary="presentation was done zero-copy"/>
+      <entry name="vsync" value="0x1">
+        <description summary="presentation was vsync'd">
+          The presentation was synchronized to the "vertical retrace" by
+          the display hardware such that tearing does not happen.
+          Relying on software scheduling is not acceptable for this
+          flag. If presentation is done by a copy to the active
+          frontbuffer, then it must guarantee that tearing cannot
+          happen.
+        </description>
+      </entry>
+      <entry name="hw_clock" value="0x2">
+        <description summary="hardware provided the presentation timestamp">
+          The display hardware provided measurements that the hardware
+          driver converted into a presentation timestamp. Sampling a
+          clock in software is not acceptable for this flag.
+        </description>
+      </entry>
+      <entry name="hw_completion" value="0x4">
+        <description summary="hardware signalled the start of the presentation">
+          The display hardware signalled that it started using the new
+          image content. The opposite of this is e.g. a timer being used
+          to guess when the display hardware has switched to the new
+          image content.
+        </description>
+      </entry>
+      <entry name="zero_copy" value="0x8">
+        <description summary="presentation was done zero-copy">
+          The presentation of this update was done zero-copy. This means
+          the buffer from the client was given to display hardware as
+          is, without copying it. Compositing with OpenGL counts as
+          copying, even if textured directly from the client buffer.
+          Possible zero-copy cases include direct scanout of a
+          fullscreen surface and a surface on a hardware overlay.
+        </description>
+      </entry>
     </enum>
 
     <event name="presented">

--- a/protocols/extra/xdg-shell.xml
+++ b/protocols/extra/xdg-shell.xml
@@ -75,7 +75,9 @@
       <description summary="create a shell surface from a surface">
 	This creates an xdg_surface for the given surface. While xdg_surface
 	itself is not a role, the corresponding surface may only be assigned
-	a role extending xdg_surface, such as xdg_toplevel or xdg_popup.
+	a role extending xdg_surface, such as xdg_toplevel or xdg_popup. It is
+	illegal to create an xdg_surface for a wl_surface which already has an
+	assigned role and this will result in a protocol error.
 
 	This creates an xdg_surface for the given surface. An xdg_surface is
 	used as basis to define a role to a given surface, such as xdg_toplevel
@@ -336,7 +338,7 @@
 
 	The default adjustment is none.
       </description>
-      <arg name="constraint_adjustment" type="uint" enum="constraint_adjustment"
+      <arg name="constraint_adjustment" type="uint"
 	   summary="bit mask of constraint adjustments"/>
     </request>
 
@@ -709,7 +711,7 @@
       <arg name="serial" type="uint" summary="the serial of the user event"/>
     </request>
 
-    <enum name="resize_edge" bitfield="true">
+    <enum name="resize_edge">
       <description summary="edge values for resizing">
 	These values are used to indicate which edge of a surface
 	is being dragged in a resize operation.
@@ -807,25 +809,25 @@
 	</description>
       </entry>
       <entry name="tiled_left" value="5" since="2">
-	<description summary="the surface is tiled">
+	<description summary="the surface’s left edge is tiled">
 	  The window is currently in a tiled layout and the left edge is
 	  considered to be adjacent to another part of the tiling grid.
 	</description>
       </entry>
       <entry name="tiled_right" value="6" since="2">
-	<description summary="the surface is tiled">
+	<description summary="the surface’s right edge is tiled">
 	  The window is currently in a tiled layout and the right edge is
 	  considered to be adjacent to another part of the tiling grid.
 	</description>
       </entry>
       <entry name="tiled_top" value="7" since="2">
-	<description summary="the surface is tiled">
+	<description summary="the surface’s top edge is tiled">
 	  The window is currently in a tiled layout and the top edge is
 	  considered to be adjacent to another part of the tiling grid.
 	</description>
       </entry>
       <entry name="tiled_bottom" value="8" since="2">
-	<description summary="the surface is tiled">
+	<description summary="the surface’s bottom edge is tiled">
 	  The window is currently in a tiled layout and the bottom edge is
 	  considered to be adjacent to another part of the tiling grid.
 	</description>

--- a/protocols/unstable/fullscreen-shell-unstable-v1.xml
+++ b/protocols/unstable/fullscreen-shell-unstable-v1.xml
@@ -112,7 +112,7 @@
 	wl_display.sync request immediately after binding to ensure that they
 	receive all the capability events.
       </description>
-      <arg name="capabilty" type="uint" enum="capability"/>
+      <arg name="capability" type="uint" enum="capability" />
     </event>
 
     <enum name="present_method">
@@ -147,9 +147,13 @@
 	operation on the surface.  This will override any kind of output
 	scaling, so the buffer_scale property of the surface is effectively
 	ignored.
+
+	This request gives the surface the role of a fullscreen shell surface.
+	If the surface already has another role, it raises a role protocol
+	error.
       </description>
       <arg name="surface" type="object" interface="wl_surface" allow-null="true"/>
-      <arg name="method" type="uint" enum="present_method"/>
+      <arg name="method" type="uint" enum="present_method" />
       <arg name="output" type="object" interface="wl_output" allow-null="true"/>
     </request>
 
@@ -192,6 +196,10 @@
 	then the compositor may choose a mode that matches either the buffer
 	size or the surface size.  In either case, the surface will fill the
 	output.
+
+	This request gives the surface the role of a fullscreen shell surface.
+	If the surface already has another role, it raises a role protocol
+	error.
       </description>
       <arg name="surface" type="object" interface="wl_surface"/>
       <arg name="output" type="object" interface="wl_output"/>
@@ -204,6 +212,7 @@
 	These errors can be emitted in response to wl_fullscreen_shell requests.
       </description>
       <entry name="invalid_method" value="0" summary="present_method is not known"/>
+      <entry name="role" value="1" summary="given wl_surface has another role"/>
     </enum>
   </interface>
 

--- a/protocols/unstable/input-method-unstable-v1.xml
+++ b/protocols/unstable/input-method-unstable-v1.xml
@@ -95,7 +95,7 @@
       </description>
       <arg name="index" type="uint"/>
       <arg name="length" type="uint"/>
-      <arg name="style" type="uint" enum="zwp_text_input_v1.preedit_style"/>
+      <arg name="style" type="uint"/>
     </request>
 
     <request name="preedit_cursor">
@@ -152,7 +152,7 @@
       <arg name="serial" type="uint" summary="serial of the latest known text input state"/>
       <arg name="time" type="uint"/>
       <arg name="sym" type="uint"/>
-      <arg name="state" type="uint" enum="wl_keyboard.key_state"/>
+      <arg name="state" type="uint"/>
       <arg name="modifiers" type="uint"/>
     </request>
 
@@ -178,7 +178,7 @@
       <arg name="serial" type="uint" summary="serial from wl_keyboard::key"/>
       <arg name="time" type="uint" summary="time from wl_keyboard::key"/>
       <arg name="key" type="uint" summary="key from wl_keyboard::key"/>
-      <arg name="state" type="uint" summary="state from wl_keyboard::key" enum="wl_keyboard.key_state"/>
+      <arg name="state" type="uint" summary="state from wl_keyboard::key"/>
     </request>
 
     <request name="modifiers">
@@ -202,7 +202,7 @@
 
     <request name="text_direction">
       <arg name="serial" type="uint" summary="serial of the latest known text input state"/>
-      <arg name="direction" type="uint"/> <!-- Left/Right enum? -->
+      <arg name="direction" type="uint"/>
     </request>
 
     <event name="surrounding_text">
@@ -222,8 +222,8 @@
     </event>
 
     <event name="content_type">
-      <arg name="hint" type="uint" enum="zwp_text_input_v1.content_hint"/>
-      <arg name="purpose" type="uint" enum="zwp_text_input_v1.content_purpose"/>
+      <arg name="hint" type="uint"/>
+      <arg name="purpose" type="uint"/>
     </event>
 
     <event name="invoke_action">
@@ -289,7 +289,7 @@
 	A keyboard surface is only shown when a text input is active.
       </description>
       <arg name="output" type="object" interface="wl_output"/>
-      <arg name="position" type="uint" enum="position"/>
+      <arg name="position" type="uint"/>
     </request>
 
     <request name="set_overlay_panel">

--- a/protocols/unstable/linux-dmabuf-unstable-v1.xml
+++ b/protocols/unstable/linux-dmabuf-unstable-v1.xml
@@ -24,17 +24,18 @@
     DEALINGS IN THE SOFTWARE.
   </copyright>
 
-  <interface name="zwp_linux_dmabuf_v1" version="3">
+  <interface name="zwp_linux_dmabuf_v1" version="4">
     <description summary="factory for creating dmabuf-based wl_buffers">
       Following the interfaces from:
       https://www.khronos.org/registry/egl/extensions/EXT/EGL_EXT_image_dma_buf_import.txt
       https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_image_dma_buf_import_modifiers.txt
       and the Linux DRM sub-system's AddFb2 ioctl.
 
-      This interface offers ways to create generic dmabuf-based
-      wl_buffers. Immediately after a client binds to this interface,
-      the set of supported formats and format modifiers is sent with
-      'format' and 'modifier' events.
+      This interface offers ways to create generic dmabuf-based wl_buffers.
+
+      Clients can use the get_surface_feedback request to get dmabuf feedback
+      for a particular surface. If the client wants to retrieve feedback not
+      tied to a surface, they can use the get_default_feedback request.
 
       The following are required from clients:
 
@@ -54,6 +55,12 @@
         for the whole lifetime of the wl_buffer. This means the server may
         at any time use those fds to import the dmabuf into any kernel
         sub-system that might accept it.
+
+      However, when the underlying graphics stack fails to deliver the
+      promise, because of e.g. a device hot-unplug which raises internal
+      errors, after the wl_buffer has been successfully created the
+      compositor must not raise protocol errors to the client when dmabuf
+      import later fails.
 
       To create a wl_buffer from one or more dmabufs, a client creates a
       zwp_linux_dmabuf_params_v1 object with a zwp_linux_dmabuf_v1.create_params
@@ -75,6 +82,9 @@
         - mark the wl_buffer as failed, and send a 'failed' event to the
           client. If the client uses a failed wl_buffer as an argument to any
           request, the behaviour is compositor implementation-defined.
+
+      For all DRM formats and unless specified in another protocol extension,
+      pre-multiplied alpha is used for pixel values.
 
       Warning! The protocol described in this file is experimental and
       backward incompatible changes may be made. Backward compatible changes
@@ -114,10 +124,9 @@
         For the definition of the format codes, see the
         zwp_linux_buffer_params_v1::create request.
 
-        Warning: the 'format' event is likely to be deprecated and replaced
-        with the 'modifier' event introduced in zwp_linux_dmabuf_v1
-        version 3, described below. Please refrain from using the information
-        received from this event.
+        Starting version 4, the format event is deprecated and must not be
+        sent by compositors. Instead, use get_default_feedback or
+        get_surface_feedback.
       </description>
       <arg name="format" type="uint" summary="DRM_FORMAT code"/>
     </event>
@@ -137,9 +146,16 @@
         is as if no explicit modifier is specified. The effective modifier
         will be derived from the dmabuf.
 
+        A compositor that sends valid modifiers and DRM_FORMAT_MOD_INVALID for
+        a given format supports both explicit modifiers and implicit modifiers.
+
         For the definition of the format and modifier codes, see the
         zwp_linux_buffer_params_v1::create and zwp_linux_buffer_params_v1::add
         requests.
+
+        Starting version 4, the modifier event is deprecated and must not be
+        sent by compositors. Instead, use get_default_feedback or
+        get_surface_feedback.
       </description>
       <arg name="format" type="uint" summary="DRM_FORMAT code"/>
       <arg name="modifier_hi" type="uint"
@@ -147,9 +163,34 @@
       <arg name="modifier_lo" type="uint"
            summary="low 32 bits of layout modifier"/>
     </event>
+
+    <!-- Version 4 additions -->
+
+    <request name="get_default_feedback" since="4">
+      <description summary="get default feedback">
+        This request creates a new wp_linux_dmabuf_feedback object not bound
+        to a particular surface. This object will deliver feedback about dmabuf
+        parameters to use if the client doesn't support per-surface feedback
+        (see get_surface_feedback).
+      </description>
+      <arg name="id" type="new_id" interface="zwp_linux_dmabuf_feedback_v1"/>
+    </request>
+
+    <request name="get_surface_feedback" since="4">
+      <description summary="get feedback for a surface">
+        This request creates a new wp_linux_dmabuf_feedback object for the
+        specified wl_surface. This object will deliver feedback about dmabuf
+        parameters to use for buffers attached to this surface.
+
+        If the surface is destroyed before the wp_linux_dmabuf_feedback object,
+        the feedback object becomes inert.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_linux_dmabuf_feedback_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
   </interface>
 
-  <interface name="zwp_linux_buffer_params_v1" version="3">
+  <interface name="zwp_linux_buffer_params_v1" version="4">
     <description summary="parameters for creating a dmabuf-based wl_buffer">
       This temporary object is a collection of dmabufs and other
       parameters that together form a single logical buffer. The temporary
@@ -206,10 +247,8 @@
         compression, etc. driver-specific modifications to the base format
         defined by the DRM fourcc code.
 
-        Warning: It should be an error if the format/modifier pair was not
-        advertised with the modifier event. This is not enforced yet because
-        some implementations always accept DRM_FORMAT_MOD_INVALID. Also
-        version 2 of this protocol does not have the modifier event.
+        Starting from version 4, the invalid_format protocol error is sent if
+        the format + modifier pair was not advertised as supported.
 
         This request raises the PLANE_IDX error if plane_idx is too large.
         The error PLANE_SET is raised if attempting to set a plane that
@@ -225,7 +264,7 @@
            summary="low 32 bits of layout modifier"/>
     </request>
 
-    <enum name="flags">
+    <enum name="flags" bitfield="true">
       <entry name="y_invert" value="1" summary="contents are y-inverted"/>
       <entry name="interlaced" value="2" summary="content is interlaced"/>
       <entry name="bottom_first" value="4" summary="bottom field first"/>
@@ -296,7 +335,7 @@
       <arg name="width" type="int" summary="base plane width in pixels"/>
       <arg name="height" type="int" summary="base plane height in pixels"/>
       <arg name="format" type="uint" summary="DRM_FORMAT code"/>
-      <arg name="flags" type="uint" summary="see enum flags" enum="flags"/>
+      <arg name="flags" type="uint" enum="flags" summary="see enum flags"/>
     </request>
 
     <event name="created">
@@ -354,9 +393,194 @@
       <arg name="width" type="int" summary="base plane width in pixels"/>
       <arg name="height" type="int" summary="base plane height in pixels"/>
       <arg name="format" type="uint" summary="DRM_FORMAT code"/>
-      <arg name="flags" type="uint" summary="see enum flags" enum="flags"/>
+      <arg name="flags" type="uint" enum="flags" summary="see enum flags"/>
+    </request>
+  </interface>
+
+  <interface name="zwp_linux_dmabuf_feedback_v1" version="4">
+    <description summary="dmabuf feedback">
+      This object advertises dmabuf parameters feedback. This includes the
+      preferred devices and the supported formats/modifiers.
+
+      The parameters are sent once when this object is created and whenever they
+      change. The done event is always sent once after all parameters have been
+      sent. When a single parameter changes, all parameters are re-sent by the
+      compositor.
+
+      Compositors can re-send the parameters when the current client buffer
+      allocations are sub-optimal. Compositors should not re-send the
+      parameters if re-allocating the buffers would not result in a more optimal
+      configuration. In particular, compositors should avoid sending the exact
+      same parameters multiple times in a row.
+
+      The tranche_target_device and tranche_modifier events are grouped by
+      tranches of preference. For each tranche, a tranche_target_device, one
+      tranche_flags and one or more tranche_modifier events are sent, followed
+      by a tranche_done event finishing the list. The tranches are sent in
+      descending order of preference. All formats and modifiers in the same
+      tranche have the same preference.
+
+      To send parameters, the compositor sends one main_device event, tranches
+      (each consisting of one tranche_target_device event, one tranche_flags
+      event, tranche_modifier events and then a tranche_done event), then one
+      done event.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the feedback object">
+        Using this request a client can tell the server that it is not going to
+        use the wp_linux_dmabuf_feedback object anymore.
+      </description>
     </request>
 
+    <event name="done">
+      <description summary="all feedback has been sent">
+        This event is sent after all parameters of a wp_linux_dmabuf_feedback
+        object have been sent.
+
+        This allows changes to the wp_linux_dmabuf_feedback parameters to be
+        seen as atomic, even if they happen via multiple events.
+      </description>
+    </event>
+
+    <event name="format_table">
+      <description summary="format and modifier table">
+        This event provides a file descriptor which can be memory-mapped to
+        access the format and modifier table.
+
+        The table contains a tightly packed array of consecutive format +
+        modifier pairs. Each pair is 16 bytes wide. It contains a format as a
+        32-bit unsigned integer, followed by 4 bytes of unused padding, and a
+        modifier as a 64-bit unsigned integer. The native endianness is used.
+
+        The client must map the file descriptor in read-only private mode.
+
+        Compositors are not allowed to mutate the table file contents once this
+        event has been sent. Instead, compositors must create a new, separate
+        table file and re-send feedback parameters. Compositors are allowed to
+        store duplicate format + modifier pairs in the table.
+      </description>
+      <arg name="fd" type="fd" summary="table file descriptor"/>
+      <arg name="size" type="uint" summary="table size, in bytes"/>
+    </event>
+
+    <event name="main_device">
+      <description summary="preferred main device">
+        This event advertises the main device that the server prefers to use
+        when direct scan-out to the target device isn't possible. The
+        advertised main device may be different for each
+        wp_linux_dmabuf_feedback object, and may change over time.
+
+        There is exactly one main device. The compositor must send at least
+        one preference tranche with tranche_target_device equal to main_device.
+
+        Clients need to create buffers that the main device can import and
+        read from, otherwise creating the dmabuf wl_buffer will fail (see the
+        wp_linux_buffer_params.create and create_immed requests for details).
+        The main device will also likely be kept active by the compositor,
+        so clients can use it instead of waking up another device for power
+        savings.
+
+        In general the device is a DRM node. The DRM node type (primary vs.
+        render) is unspecified. Clients must not rely on the compositor sending
+        a particular node type. Clients cannot check two devices for equality
+        by comparing the dev_t value.
+
+        If explicit modifiers are not supported and the client performs buffer
+        allocations on a different device than the main device, then the client
+        must force the buffer to have a linear layout.
+      </description>
+      <arg name="device" type="array" summary="device dev_t value"/>
+    </event>
+
+    <event name="tranche_done">
+      <description summary="a preference tranche has been sent">
+        This event splits tranche_target_device and tranche_modifier events in
+        preference tranches. It is sent after a set of tranche_target_device
+        and tranche_modifier events; it represents the end of a tranche. The
+        next tranche will have a lower preference.
+      </description>
+    </event>
+
+    <event name="tranche_target_device">
+      <description summary="target device">
+        This event advertises the target device that the server prefers to use
+        for a buffer created given this tranche. The advertised target device
+        may be different for each preference tranche, and may change over time.
+
+        There is exactly one target device per tranche.
+
+        The target device may be a scan-out device, for example if the
+        compositor prefers to directly scan-out a buffer created given this
+        tranche. The target device may be a rendering device, for example if
+        the compositor prefers to texture from said buffer.
+
+        The client can use this hint to allocate the buffer in a way that makes
+        it accessible from the target device, ideally directly. The buffer must
+        still be accessible from the main device, either through direct import
+        or through a potentially more expensive fallback path. If the buffer
+        can't be directly imported from the main device then clients must be
+        prepared for the compositor changing the tranche priority or making
+        wl_buffer creation fail (see the wp_linux_buffer_params.create and
+        create_immed requests for details).
+
+        If the device is a DRM node, the DRM node type (primary vs. render) is
+        unspecified. Clients must not rely on the compositor sending a
+        particular node type. Clients cannot check two devices for equality by
+        comparing the dev_t value.
+
+        This event is tied to a preference tranche, see the tranche_done event.
+      </description>
+      <arg name="device" type="array" summary="device dev_t value"/>
+    </event>
+
+    <event name="tranche_formats">
+      <description summary="supported buffer format modifier">
+        This event advertises the format + modifier combinations that the
+        compositor supports.
+
+        It carries an array of indices, each referring to a format + modifier
+        pair in the last received format table (see the format_table event).
+        Each index is a 16-bit unsigned integer in native endianness.
+
+        For legacy support, DRM_FORMAT_MOD_INVALID is an allowed modifier.
+        It indicates that the server can support the format with an implicit
+        modifier. When a buffer has DRM_FORMAT_MOD_INVALID as its modifier, it
+        is as if no explicit modifier is specified. The effective modifier
+        will be derived from the dmabuf.
+
+        A compositor that sends valid modifiers and DRM_FORMAT_MOD_INVALID for
+        a given format supports both explicit modifiers and implicit modifiers.
+
+        Compositors must not send duplicate format + modifier pairs within the
+        same tranche or across two different tranches with the same target
+        device and flags.
+
+        This event is tied to a preference tranche, see the tranche_done event.
+
+        For the definition of the format and modifier codes, see the
+        wp_linux_buffer_params.create request.
+      </description>
+      <arg name="indices" type="array" summary="array of 16-bit indexes"/>
+    </event>
+
+    <enum name="tranche_flags" bitfield="true">
+      <entry name="scanout" value="1" summary="direct scan-out tranche"/>
+    </enum>
+
+    <event name="tranche_flags">
+      <description summary="tranche flags">
+        This event sets tranche-specific flags.
+
+        The scanout flag is a hint that direct scan-out may be attempted by the
+        compositor on the target device if the client appropriately allocates a
+        buffer. How to allocate a buffer that can be scanned out on the target
+        device is implementation-defined.
+
+        This event is tied to a preference tranche, see the tranche_done event.
+      </description>
+      <arg name="flags" type="uint" enum="tranche_flags" summary="tranche flags"/>
+    </event>
   </interface>
 
 </protocol>

--- a/protocols/unstable/pointer-gestures-unstable-v1.xml
+++ b/protocols/unstable/pointer-gestures-unstable-v1.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <protocol name="pointer_gestures_unstable_v1">
 
-  <interface name="zwp_pointer_gestures_v1" version="2">
+  <interface name="zwp_pointer_gestures_v1" version="3">
     <description summary="touchpad gestures">
       A global interface to provide semantic touchpad gestures for a given
       pointer.
 
-      Two gestures are currently supported: swipe and zoom/rotate.
-      All gestures follow a three-stage cycle: begin, update, end and
-      are identified by a unique id.
+      Three gestures are currently supported: swipe, pinch, and hold.
+      Pinch and swipe gestures follow a three-stage cycle: begin, update,
+      end, hold gestures follow a two-stage cycle: begin and end. All
+      gestures are identified by a unique id.
 
       Warning! The protocol described in this file is experimental and
       backward incompatible changes may be made. Backward compatible changes
@@ -42,10 +43,22 @@
 
     <request name="release" type="destructor" since="2">
       <description summary="destroy the pointer gesture object">
-	Destroy the pointer gesture object. Swipe and pinch objects created via this
-	gesture object remain valid.
+	Destroy the pointer gesture object. Swipe, pinch and hold objects
+	created via this gesture object remain valid.
       </description>
     </request>
+
+    <!-- Version 3 additions -->
+
+    <request name="get_hold_gesture" since="3">
+      <description summary="get hold gesture">
+	Create a hold gesture object. See the
+	wl_pointer_gesture_hold interface for details.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_pointer_gesture_hold_v1"/>
+      <arg name="pointer" type="object" interface="wl_pointer"/>
+    </request>
+
   </interface>
 
   <interface name="zwp_pointer_gesture_swipe_v1" version="2">
@@ -58,7 +71,7 @@
       implementation-dependent.
 
       A gesture consists of three stages: begin, update (optional) and end.
-      There cannot be multiple simultaneous pinch or swipe gestures on a
+      There cannot be multiple simultaneous hold, pinch or swipe gestures on a
       same pointer/seat, how compositors prevent these situations is
       implementation-dependent.
 
@@ -121,7 +134,7 @@
       such a gesture is detected are implementation-dependent.
 
       A gesture consists of three stages: begin, update (optional) and end.
-      There cannot be multiple simultaneous pinch or swipe gestures on a
+      There cannot be multiple simultaneous hold, pinch or swipe gestures on a
       same pointer/seat, how compositors prevent these situations is
       implementation-dependent.
 
@@ -181,6 +194,60 @@
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
       <arg name="cancelled" type="int" summary="1 if the gesture was cancelled, 0 otherwise"/>
     </event>
+
   </interface>
 
+  <interface name="zwp_pointer_gesture_hold_v1" version="3">
+    <description summary="a hold gesture object">
+      A hold gesture object notifies a client about a single- or
+      multi-finger hold gesture detected on an indirect input device such as
+      a touchpad. The gesture is usually initiated by one or more fingers
+      being held down without significant movement. The precise conditions
+      of when such a gesture is detected are implementation-dependent.
+
+      In particular, this gesture may be used to cancel kinetic scrolling.
+
+      A hold gesture consists of two stages: begin and end. Unlike pinch and
+      swipe there is no update stage.
+      There cannot be multiple simultaneous hold, pinch or swipe gestures on a
+      same pointer/seat, how compositors prevent these situations is
+      implementation-dependent.
+
+      A gesture may be cancelled by the compositor or the hardware.
+      Clients should not consider performing permanent or irreversible
+      actions until the end of a gesture has been received.
+    </description>
+
+    <request name="destroy" type="destructor" since="3">
+      <description summary="destroy the hold gesture object"/>
+    </request>
+
+    <event name="begin" since="3">
+      <description summary="multi-finger hold begin">
+	This event is sent when a hold gesture is detected on the device.
+      </description>
+      <arg name="serial" type="uint"/>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="fingers" type="uint" summary="number of fingers"/>
+    </event>
+
+    <event name="end" since="3">
+      <description summary="multi-finger hold end">
+	This event is sent when a hold gesture ceases to
+	be valid. This may happen when the holding fingers are lifted or
+	the gesture is cancelled, for example if the fingers move past an
+	implementation-defined threshold, the finger count changes or the hold
+	gesture changes into a different type of gesture.
+
+	When a gesture is cancelled, the client may need to undo state changes
+	caused by this gesture. What causes a gesture to be cancelled is
+	implementation-dependent.
+      </description>
+      <arg name="serial" type="uint"/>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="cancelled" type="int" summary="1 if the gesture was cancelled, 0 otherwise"/>
+    </event>
+
+  </interface>
 </protocol>

--- a/protocols/unstable/text-input-unstable-v1.xml
+++ b/protocols/unstable/text-input-unstable-v1.xml
@@ -113,7 +113,7 @@
       <arg name="anchor" type="uint"/>
     </request>
 
-    <enum name="content_hint">
+    <enum name="content_hint" bitfield="true">
       <description summary="content hint">
 	Content hint is a bitmask to allow to modify the behavior of the text
 	input.
@@ -166,8 +166,8 @@
 	default hints (auto completion, auto correction, auto capitalization)
 	should be assumed.
       </description>
-      <arg name="hint" type="uint" enum="content_hint"/>
-      <arg name="purpose" type="uint" enum="content_purpose"/>
+      <arg name="hint" type="uint" enum="content_hint" />
+      <arg name="purpose" type="uint" enum="content_purpose" />
     </request>
 
     <request name="set_cursor_rectangle">
@@ -271,7 +271,7 @@
       </description>
       <arg name="index" type="uint"/>
       <arg name="length" type="uint"/>
-      <arg name="style" type="uint" enum="preedit_style"/>
+      <arg name="style" type="uint" enum="preedit_style" />
     </event>
 
     <event name="preedit_cursor">
@@ -337,7 +337,7 @@
       <arg name="serial" type="uint" summary="serial of the latest known text input state"/>
       <arg name="time" type="uint"/>
       <arg name="sym" type="uint"/>
-      <arg name="state" type="uint" enum="wl_keyboard.key_state"/>
+      <arg name="state" type="uint"/>
       <arg name="modifiers" type="uint"/>
     </event>
 
@@ -365,7 +365,7 @@
 	direction text is laid out properly.
       </description>
       <arg name="serial" type="uint" summary="serial of the latest known text input state"/>
-      <arg name="direction" type="uint" enum="text_direction"/>
+      <arg name="direction" type="uint" enum="text_direction" />
     </event>
   </interface>
 

--- a/protocols/unstable/text-input-unstable-v3.xml
+++ b/protocols/unstable/text-input-unstable-v3.xml
@@ -94,6 +94,12 @@
         zwp_text_input_v3.disable when there is no longer any input focus on
         the current surface.
 
+        Clients must not enable more than one text input on the single seat
+        and should disable the current text input before enabling the new one.
+        At most one instance of text input may be in enabled state per instance,
+        Requests to enable the another text input when some text input is active
+        must be ignored by compositor.
+
         This request resets all state associated with previous enable, disable,
         set_surrounding_text, set_text_change_cause, set_content_type, and
         set_cursor_rectangle requests, as well as the state associated with
@@ -307,6 +313,9 @@
       <description summary="enter event">
         Notification that this seat's text-input focus is on a certain surface.
 
+        If client has created multiple text input objects, compositor must send
+        this event to all of them.
+
         When the seat has the keyboard capability the text-input focus follows
         the keyboard focus. This event sets the current surface for the
         text-input object.
@@ -321,7 +330,9 @@
         set.
 
         The leave notification clears the current surface. It is sent before
-        the enter notification for the new focus.
+        the enter notification for the new focus. After leave event, compositor
+        must ignore requests from any text input instances until next enter
+        event.
 
         When the seat has the keyboard capability the text-input focus follows
         the keyboard focus.

--- a/protocols/unstable/xdg-foreign-unstable-v2.xml
+++ b/protocols/unstable/xdg-foreign-unstable-v2.xml
@@ -69,6 +69,14 @@
       </description>
     </request>
 
+    <enum name="error">
+      <description summary="error values">
+        These errors can be emitted in response to invalid xdg_exporter
+        requests.
+      </description>
+      <entry name="invalid_surface" value="0" summary="surface is not an xdg_toplevel"/>
+    </enum>
+
     <request name="export_toplevel">
       <description summary="export a toplevel surface">
 	The export_toplevel request exports the passed surface so that it can later be
@@ -78,7 +86,8 @@
 
 	A surface may be exported multiple times, and each exported handle may
 	be used to create an xdg_imported multiple times. Only xdg_toplevel
-	equivalent surfaces may be exported.
+        equivalent surfaces may be exported, otherwise an invalid_surface
+        protocol error is sent.
       </description>
       <arg name="id" type="new_id" interface="zxdg_exported_v2"
 	   summary="the new xdg_exported object"/>
@@ -150,6 +159,14 @@
       relationships between its own surfaces and the imported surface.
     </description>
 
+    <enum name="error">
+      <description summary="error values">
+        These errors can be emitted in response to invalid xdg_imported
+        requests.
+      </description>
+      <entry name="invalid_surface" value="0" summary="surface is not an xdg_toplevel"/>
+    </enum>
+
     <request name="destroy" type="destructor">
       <description summary="destroy the xdg_imported object">
 	Notify the compositor that it will no longer use the xdg_imported
@@ -160,10 +177,11 @@
 
     <request name="set_parent_of">
       <description summary="set as the parent of some surface">
-	Set the imported surface as the parent of some surface of the client.
-	The passed surface must be an xdg_toplevel equivalent. Calling this
-	function sets up a surface to surface relation with the same stacking
-	and positioning semantics as xdg_toplevel.set_parent.
+        Set the imported surface as the parent of some surface of the client.
+        The passed surface must be an xdg_toplevel equivalent, otherwise an
+        invalid_surface protocol error is sent. Calling this function sets up
+        a surface to surface relation with the same stacking and positioning
+        semantics as xdg_toplevel.set_parent.
       </description>
       <arg name="surface" type="object" interface="wl_surface"
 	   summary="the child surface"/>

--- a/protocols/unstable/xdg-output-unstable-v1.xml
+++ b/protocols/unstable/xdg-output-unstable-v1.xml
@@ -138,7 +138,7 @@
 	  advertise a logical size of 1920×1080,
 
 	- A compositor using a fractional scale of 1.5 will advertise a
-	  logical size to 2560×1620.
+	  logical size of 2560×1440.
 
 	For example, for a wl_output mode 1920×1080 and a 90 degree rotation,
 	the compositor will advertise a logical size of 1080x1920.

--- a/protocols/unstable/xdg-shell-unstable-v6.xml
+++ b/protocols/unstable/xdg-shell-unstable-v6.xml
@@ -338,7 +338,7 @@
 
 	The default adjustment is none.
       </description>
-      <arg name="constraint_adjustment" type="uint" enum="constraint_adjustment"
+      <arg name="constraint_adjustment" type="uint"
 	   summary="bit mask of constraint adjustments"/>
     </request>
 
@@ -625,7 +625,7 @@
       <arg name="serial" type="uint" summary="the serial of the user event"/>
     </request>
 
-    <enum name="resize_edge" bitfield="true">
+    <enum name="resize_edge">
       <description summary="edge values for resizing">
 	These values are used to indicate which edge of a surface
 	is being dragged in a resize operation.
@@ -676,7 +676,7 @@
       </description>
       <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
       <arg name="serial" type="uint" summary="the serial of the user event"/>
-      <arg name="edges" type="uint" enum="resize_edge" summary="which edge or corner is being dragged"/>
+      <arg name="edges" type="uint" summary="which edge or corner is being dragged"/>
     </request>
 
     <enum name="state">

--- a/protocols/wayland.xml
+++ b/protocols/wayland.xml
@@ -179,7 +179,7 @@
       the related request is done.
     </description>
 
-    <event name="done">
+    <event name="done" type="destructor">
       <description summary="done event">
 	Notify the client when the related request is done.
       </description>
@@ -187,7 +187,7 @@
     </event>
   </interface>
 
-  <interface name="wl_compositor" version="4">
+  <interface name="wl_compositor" version="5">
     <description summary="the compositor singleton">
       A compositor.  This object is a singleton global.  The
       compositor is in charge of combining the contents of multiple
@@ -296,6 +296,9 @@
 	The drm format codes match the macros defined in drm_fourcc.h, except
 	argb8888 and xrgb8888. The formats actually supported by the compositor
 	will be reported by the format event.
+
+	For all wl_shm formats and unless specified in another protocol
+	extension, pre-multiplied alpha is used for pixel values.
       </description>
       <!-- Note to protocol writers: don't update this list manually, instead
 	   run the automated script that keeps it in sync with drm_fourcc.h. -->
@@ -399,6 +402,14 @@
       <entry name="p010" value="0x30313050" summary="2x2 subsampled Cr:Cb plane 10 bits per channel"/>
       <entry name="p012" value="0x32313050" summary="2x2 subsampled Cr:Cb plane 12 bits per channel"/>
       <entry name="p016" value="0x36313050" summary="2x2 subsampled Cr:Cb plane 16 bits per channel"/>
+      <entry name="axbxgxrx106106106106" value="0x30314241" summary="[63:0] A:x:B:x:G:x:R:x 10:6:10:6:10:6:10:6 little endian"/>
+      <entry name="nv15" value="0x3531564e" summary="2x2 subsampled Cr:Cb plane"/>
+      <entry name="q410" value="0x30313451"/>
+      <entry name="q401" value="0x31303451"/>
+      <entry name="xrgb16161616" value="0x38345258" summary="[63:0] x:R:G:B 16:16:16:16 little endian"/>
+      <entry name="xbgr16161616" value="0x38344258" summary="[63:0] x:B:G:R 16:16:16:16 little endian"/>
+      <entry name="argb16161616" value="0x38345241" summary="[63:0] A:R:G:B 16:16:16:16 little endian"/>
+      <entry name="abgr16161616" value="0x38344241" summary="[63:0] A:B:G:R 16:16:16:16 little endian"/>
     </enum>
 
     <request name="create_pool">
@@ -427,10 +438,15 @@
   <interface name="wl_buffer" version="1">
     <description summary="content for a wl_surface">
       A buffer provides the content for a wl_surface. Buffers are
-      created through factory interfaces such as wl_drm, wl_shm or
-      similar. It has a width and a height and can be attached to a
-      wl_surface, but the mechanism by which a client provides and
-      updates the contents is defined by the buffer factory interface.
+      created through factory interfaces such as wl_shm, wp_linux_buffer_params
+      (from the linux-dmabuf protocol extension) or similar. It has a width and
+      a height and can be attached to a wl_surface, but the mechanism by which a
+      client provides and updates the contents is defined by the buffer factory
+      interface.
+
+      If the buffer uses a format that has an alpha channel, the alpha channel
+      is assumed to be premultiplied in the color channels unless otherwise
+      specified.
     </description>
 
     <request name="destroy" type="destructor">
@@ -829,7 +845,8 @@
 	for the eventual data transfer. If source is NULL, enter, leave
 	and motion events are sent only to the client that initiated the
 	drag and the client is expected to handle the data passing
-	internally.
+	internally. If source is destroyed, the drag-and-drop session will be
+	cancelled.
 
 	The origin surface is the surface where the drag originates and
 	the client must have an active implicit grab that matches the
@@ -943,9 +960,10 @@
 	immediately before receiving keyboard focus and when a new
 	selection is set while the client has keyboard focus.  The
 	data_offer is valid until a new data_offer or NULL is received
-	or until the client loses keyboard focus.  The client must
-	destroy the previous selection data_offer, if any, upon receiving
-	this event.
+	or until the client loses keyboard focus.  Switching surface with
+	keyboard focus within the same client doesn't mean a new selection
+	will be sent.  The client must destroy the previous selection
+	data_offer, if any, upon receiving this event.
       </description>
       <arg name="id" type="object" interface="wl_data_offer" allow-null="true"
 	   summary="selection data_offer object"/>
@@ -1327,7 +1345,7 @@
     </event>
   </interface>
 
-  <interface name="wl_surface" version="4">
+  <interface name="wl_surface" version="5">
     <description summary="an onscreen surface">
       A surface is a rectangular area that may be displayed on zero
       or more outputs, and shown any number of times at the compositor's
@@ -1379,6 +1397,7 @@
       <entry name="invalid_scale" value="0" summary="buffer scale value is invalid"/>
       <entry name="invalid_transform" value="1" summary="buffer transform value is invalid"/>
       <entry name="invalid_size" value="2" summary="buffer size is invalid"/>
+      <entry name="invalid_offset" value="3" summary="buffer offset is invalid"/>
     </enum>
 
     <request name="destroy" type="destructor">
@@ -1401,7 +1420,14 @@
 	buffer's upper left corner, relative to the current buffer's upper
 	left corner, in surface-local coordinates. In other words, the
 	x and y, combined with the new surface size define in which
-	directions the surface's size changes.
+	directions the surface's size changes. Setting anything other than 0
+	as x and y arguments is discouraged, and should instead be replaced
+	with using the separate wl_surface.offset request.
+
+	When the bound wl_surface version is 5 or higher, passing any
+	non-zero x or y is a protocol violation, and will result in an
+	'invalid_offset' error being raised. To achieve equivalent semantics,
+	use wl_surface.offset.
 
 	Surface contents are double-buffered state, see wl_surface.commit.
 
@@ -1429,9 +1455,12 @@
 	from the same backing storage or use wp_linux_buffer_release.
 
 	Destroying the wl_buffer after wl_buffer.release does not change
-	the surface contents. However, if the client destroys the
-	wl_buffer before receiving the wl_buffer.release event, the surface
-	contents become undefined immediately.
+	the surface contents. Destroying the wl_buffer before wl_buffer.release
+	is allowed as long as the underlying buffer storage isn't re-used (this
+	can happen e.g. on client process termination). However, if the client
+	destroys the wl_buffer before receiving the wl_buffer.release event and
+	mutates the underlying buffer storage, the surface contents become
+	undefined immediately.
 
 	If wl_surface.attach is sent with a NULL wl_buffer, the
 	following wl_surface.commit will remove the surface content.
@@ -1608,6 +1637,12 @@
 	This is emitted whenever a surface's creation, movement, or resizing
 	results in it no longer having any part of it within the scanout region
 	of an output.
+
+	Clients should not use the number of outputs the surface is on for frame
+	throttling purposes. The surface might be hidden even if no leave event
+	has been sent, and the compositor might expect new surface content
+	updates even if no enter event has been sent. The frame event should be
+	used instead.
       </description>
       <arg name="output" type="object" interface="wl_output" summary="output left by the surface"/>
     </event>
@@ -1723,6 +1758,27 @@
       <arg name="width" type="int" summary="width of damage rectangle"/>
       <arg name="height" type="int" summary="height of damage rectangle"/>
     </request>
+
+    <!-- Version 5 additions -->
+
+    <request name="offset" since="5">
+      <description summary="set the surface contents offset">
+	The x and y arguments specify the location of the new pending
+	buffer's upper left corner, relative to the current buffer's upper
+	left corner, in surface-local coordinates. In other words, the
+	x and y, combined with the new surface size define in which
+	directions the surface's size changes.
+
+	Surface location offset is double-buffered state, see
+	wl_surface.commit.
+
+	This request is semantically equivalent to and the replaces the x and y
+	arguments in the wl_surface.attach request in wl_surface versions prior
+	to 5. See wl_surface.attach for details.
+      </description>
+      <arg name="x" type="int" summary="surface-local x coordinate"/>
+      <arg name="y" type="int" summary="surface-local y coordinate"/>
+    </request>
    </interface>
 
   <interface name="wl_seat" version="7">
@@ -1827,9 +1883,22 @@
 
     <event name="name" since="2">
       <description summary="unique identifier for this seat">
-	In a multiseat configuration this can be used by the client to help
-	identify which physical devices the seat represents. Based on
-	the seat configuration used by the compositor.
+	In a multi-seat configuration the seat name can be used by clients to
+	help identify which physical devices the seat represents.
+
+	The seat name is a UTF-8 string with no convention defined for its
+	contents. Each name is unique among all wl_seat globals. The name is
+	only guaranteed to be unique for the current compositor instance.
+
+	The same seat names are used for all clients. Thus, the name can be
+	shared across processes to refer to a specific wl_seat global.
+
+	The name event is sent after binding to the seat global. This event is
+	only sent once per seat object, and the name does not change over the
+	lifetime of the wl_seat global.
+
+	Compositors may re-use the same seat name if the wl_seat global is
+	destroyed and re-created later.
       </description>
       <arg name="name" type="string" summary="seat identifier"/>
     </event>
@@ -1894,6 +1963,10 @@
 	wl_surface is no longer used as the cursor. When the use as a
 	cursor ends, the current and pending input regions become
 	undefined, and the wl_surface is unmapped.
+
+	The serial parameter must match the latest wl_pointer.enter
+	serial number sent to the client. Otherwise the request will be
+	ignored.
       </description>
       <arg name="serial" type="uint" summary="serial number of the enter event"/>
       <arg name="surface" type="object" interface="wl_surface" allow-null="true"
@@ -2188,7 +2261,8 @@
     <event name="keymap">
       <description summary="keyboard mapping">
 	This event provides a file descriptor to the client which can be
-	memory-mapped to provide a keyboard mapping description.
+	memory-mapped in read-only mode to provide a keyboard mapping
+	description.
 
 	From version 7 onwards, the fd must be mapped with MAP_PRIVATE by
 	the recipient, as MAP_SHARED may fail.
@@ -2438,7 +2512,7 @@
     </event>
   </interface>
 
-  <interface name="wl_output" version="3">
+  <interface name="wl_output" version="4">
     <description summary="compositor output region">
       An output describes part of the compositor geometry.  The
       compositor works in the 'compositor coordinate system' and an
@@ -2461,7 +2535,7 @@
       <entry name="vertical_bgr" value="5" summary="vertical BGR"/>
     </enum>
 
-    <enum name="transform" bitfield="true">
+    <enum name="transform">
       <description summary="transform from framebuffer to output">
 	This describes the transform that a compositor will apply to a
 	surface to compensate for the rotation or mirroring of an
@@ -2494,12 +2568,15 @@
 	The physical size can be set to zero if it doesn't make sense for this
 	output (e.g. for projectors or virtual outputs).
 
+	The geometry event will be followed by a done event (starting from
+	version 2).
+
 	Note: wl_output only advertises partial information about the output
 	position and identification. Some compositors, for instance those not
 	implementing a desktop-style output layout or those exposing virtual
 	outputs, might fake this information. Instead of using x and y, clients
 	should use xdg_output.logical_position. Instead of using make and model,
-	clients should use xdg_output.name and xdg_output.description.
+	clients should use name and description.
       </description>
       <arg name="x" type="int"
 	   summary="x position within the global compositor space"/>
@@ -2540,6 +2617,10 @@
 	current.  In other words, the current mode is always the last
 	mode that was received with the current flag set.
 
+	Non-current modes are deprecated. A compositor can decide to only
+	advertise the current mode and never send other modes. Clients
+	should not rely on non-current modes.
+
 	The size of a mode is given in physical hardware units of
 	the output device. This is not necessarily the same as
 	the output size in the global compositor space. For instance,
@@ -2550,6 +2631,9 @@
 
 	The vertical refresh rate can be set to zero if it doesn't make
 	sense for this output (e.g. for virtual outputs).
+
+	The mode event will be followed by a done event (starting from
+	version 2).
 
 	Clients should not use the refresh rate to schedule frames. Instead,
 	they should use the wl_surface.frame event or the presentation-time
@@ -2597,6 +2681,8 @@
 	the scale of the output. That way the compositor can
 	avoid scaling the surface, and the client can supply
 	a higher detail image.
+
+	The scale event will be followed by a done event.
       </description>
       <arg name="factor" type="int" summary="scaling factor of output"/>
     </event>
@@ -2609,6 +2695,62 @@
 	use the output object anymore.
       </description>
     </request>
+
+    <!-- Version 4 additions -->
+
+    <event name="name" since="4">
+      <description summary="name of this output">
+	Many compositors will assign user-friendly names to their outputs, show
+	them to the user, allow the user to refer to an output, etc. The client
+	may wish to know this name as well to offer the user similar behaviors.
+
+	The name is a UTF-8 string with no convention defined for its contents.
+	Each name is unique among all wl_output globals. The name is only
+	guaranteed to be unique for the compositor instance.
+
+	The same output name is used for all clients for a given wl_output
+	global. Thus, the name can be shared across processes to refer to a
+	specific wl_output global.
+
+	The name is not guaranteed to be persistent across sessions, thus cannot
+	be used to reliably identify an output in e.g. configuration files.
+
+	Examples of names include 'HDMI-A-1', 'WL-1', 'X11-1', etc. However, do
+	not assume that the name is a reflection of an underlying DRM connector,
+	X11 connection, etc.
+
+	The name event is sent after binding the output object. This event is
+	only sent once per output object, and the name does not change over the
+	lifetime of the wl_output global.
+
+	Compositors may re-use the same output name if the wl_output global is
+	destroyed and re-created later. Compositors should avoid re-using the
+	same name if possible.
+
+	The name event will be followed by a done event.
+      </description>
+      <arg name="name" type="string" summary="output name"/>
+    </event>
+
+    <event name="description" since="4">
+      <description summary="human-readable description of this output">
+	Many compositors can produce human-readable descriptions of their
+	outputs. The client may wish to know this description as well, e.g. for
+	output selection purposes.
+
+	The description is a UTF-8 string with no convention defined for its
+	contents. The description is not guaranteed to be unique among all
+	wl_output globals. Examples might include 'Foocorp 11" Display' or
+	'Virtual X11 output via :1'.
+
+	The description event is sent after binding the output object and
+	whenever the description changes. The description is optional, and may
+	not be sent at all.
+
+	The description event will be followed by a done event.
+      </description>
+      <arg name="description" type="string" summary="output description"/>
+    </event>
   </interface>
 
   <interface name="wl_region" version="1">
@@ -2732,7 +2874,7 @@
       wl_surface state directly. A sub-surface is initially in the
       synchronized mode.
 
-      Sub-surfaces have also other kind of state, which is managed by
+      Sub-surfaces also have another kind of state, which is managed by
       wl_subsurface requests, as opposed to wl_surface requests. This
       state includes the sub-surface position relative to the parent
       surface (wl_subsurface.set_position), and the stacking order of


### PR DESCRIPTION
My environment: Gentoo Linux / Sway 1.7 / wlroots 0.15.0

Since wlroots 0.15.0, it exposes wl_output version 4.
So error `interface 'wl_output' has no event 4` occurs (see this [Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=1279681)).

Updating wayland protocols to version 1.24 solved this issue.