### PR TITLE
add missing <cstdint> include

### DIFF
--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -29,6 +29,7 @@
 /** \file */
 
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>

--- a/scanner/scanner.cpp
+++ b/scanner/scanner.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <cctype>
 #include <cmath>
+#include <cstdint>
 #include <stdexcept>
 
 #include "pugixml.hpp"
@@ -1106,6 +1107,7 @@ int main(int argc, char *argv[])
   wayland_hpp << "#pragma once" << std::endl
               << std::endl
               << "#include <array>" << std::endl
+              << "#include <cstdint>" << std::endl
               << "#include <functional>" << std::endl
               << "#include <memory>" << std::endl
               << "#include <string>" << std::endl
@@ -1125,6 +1127,7 @@ int main(int argc, char *argv[])
     wayland_server_hpp << "#pragma once" << std::endl
                        << std::endl
                        << "#include <array>" << std::endl
+                       << "#include <cstdint>" << std::endl
                        << "#include <functional>" << std::endl
                        << "#include <memory>" << std::endl
                        << "#include <string>" << std::endl


### PR DESCRIPTION
Upcoming `gcc-13` made `<string>` leaner and does not include `<cstdint>` implicitly anymore. As a result build fails without the change as:

    [  2%] Building CXX object CMakeFiles/wayland-scanner++.dir/scanner/scanner.cpp.o
    scanner/scanner.cpp:378:3: error: 'uint32_t' does not name a type
      378 |   uint32_t width = 0;
          |   ^~~~~~~~