### PR TITLE
include missing <cstdint>

### DIFF
--- a/include/wayland-client.hpp
+++ b/include/wayland-client.hpp
@@ -29,6 +29,7 @@
 /** \file */
 
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>

--- a/scanner/scanner.cpp
+++ b/scanner/scanner.cpp
@@ -15,6 +15,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <list>
@@ -1106,6 +1107,7 @@ int main(int argc, char *argv[])
   wayland_hpp << "#pragma once" << std::endl
               << std::endl
               << "#include <array>" << std::endl
+              << "#include <cstdint>" << std::endl
               << "#include <functional>" << std::endl
               << "#include <memory>" << std::endl
               << "#include <string>" << std::endl
@@ -1125,6 +1127,7 @@ int main(int argc, char *argv[])
     wayland_server_hpp << "#pragma once" << std::endl
                        << std::endl
                        << "#include <array>" << std::endl
+                       << "#include <cstdint>" << std::endl
                        << "#include <functional>" << std::endl
                        << "#include <memory>" << std::endl
                        << "#include <string>" << std::endl


### PR DESCRIPTION
gcc 13 moved some includes around and as a result <cstdint> is no longer transitively included [1]. Explicitly include it for uint{32,64}_t.

[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

Signed-off-by: Khem Raj <raj.khem@gmail.com>