### PR TITLE
[scanner] Create static member for each interface to get static version

### DIFF
--- a/example/dump.cpp
+++ b/example/dump.cpp
@@ -62,7 +62,7 @@ public:
       {
         outputs.emplace_back();
         auto& output = outputs.back();
-        registry.bind(name, output, version);
+        registry.bind(name, output, std::min(output_t::interface_version, version));
       }
     };
     // Print global information

--- a/example/egl.cpp
+++ b/example/egl.cpp
@@ -39,16 +39,6 @@
 
 using namespace wayland;
 
-// helper to create a std::function out of a member function and an object
-template <typename R, typename T, typename... Args>
-std::function<R(Args...)> bind_mem_fn(R(T::* func)(Args...), T *t)
-{
-  return [func, t] (Args... args)
-  {
-    return (t->*func)(args...);
-  };
-}
-
 // example Wayland client
 class example
 {
@@ -175,7 +165,7 @@ private:
 
     // schedule next draw
     frame_cb = surface.frame();
-    frame_cb.on_done() = bind_mem_fn(&example::draw, this);
+    frame_cb.on_done() = std::bind(&example::draw, this, std::placeholders::_1);
 
     // swap buffers
     if(eglSwapBuffers(egldisplay, eglsurface) == EGL_FALSE)

--- a/example/egl.cpp
+++ b/example/egl.cpp
@@ -195,15 +195,15 @@ public:
     registry.on_global() = [&] (uint32_t name, const std::string& interface, uint32_t version)
     {
       if(interface == compositor_t::interface_name)
-        registry.bind(name, compositor, version);
+        registry.bind(name, compositor, std::min(compositor_t::interface_version, version));
       else if(interface == shell_t::interface_name)
-        registry.bind(name, shell, version);
+        registry.bind(name, shell, std::min(shell_t::interface_version, version));
       else if(interface == xdg_wm_base_t::interface_name)
-        registry.bind(name, xdg_wm_base, version);
+        registry.bind(name, xdg_wm_base, std::min(xdg_wm_base_t::interface_version, version));
       else if(interface == seat_t::interface_name)
-        registry.bind(name, seat, version);
+        registry.bind(name, seat, std::min(seat_t::interface_version, version));
       else if(interface == shm_t::interface_name)
-        registry.bind(name, shm, version);
+        registry.bind(name, shm, std::min(shm_t::interface_version, version));
     };
     display.roundtrip();
 

--- a/example/pingpong.cpp
+++ b/example/pingpong.cpp
@@ -79,7 +79,7 @@ int main()
   {
     std::cout << "Found global: " << interface << std::endl;
     if(interface == wayland::pingpong_t::interface_name)
-      registry.bind(name, pingpong, version);
+      registry.bind(name, pingpong, std::min(wayland::pingpong_t::interface_version, version));
   };
   display.roundtrip();
 

--- a/example/proxy_wrapper.cpp
+++ b/example/proxy_wrapper.cpp
@@ -69,7 +69,7 @@ private:
     registry.on_global() = [&seat, &registry](std::uint32_t name, const std::string& interface, std::uint32_t version)
     {
       if(interface == seat_t::interface_name)
-        registry.bind(name, seat, version);
+        registry.bind(name, seat, std::min(seat_t::interface_version, version));
     };
     display.roundtrip_queue(queue);
     if(!seat)

--- a/example/shm.cpp
+++ b/example/shm.cpp
@@ -228,15 +228,15 @@ public:
     registry.on_global() = [&] (uint32_t name, const std::string& interface, uint32_t version)
     {
       if(interface == compositor_t::interface_name)
-        registry.bind(name, compositor, version);
+        registry.bind(name, compositor, std::min(compositor_t::interface_version, version));
       else if(interface == shell_t::interface_name)
-        registry.bind(name, shell, version);
+        registry.bind(name, shell, std::min(shell_t::interface_version, version));
       else if(interface == xdg_wm_base_t::interface_name)
-        registry.bind(name, xdg_wm_base, version);
+        registry.bind(name, xdg_wm_base, std::min(xdg_wm_base_t::interface_version, version));
       else if(interface == seat_t::interface_name)
-        registry.bind(name, seat, version);
+        registry.bind(name, seat, std::min(seat_t::interface_version, version));
       else if(interface == shm_t::interface_name)
-        registry.bind(name, shm, version);
+        registry.bind(name, shm, std::min(shm_t::interface_version, version));
     };
     display.roundtrip();
 

--- a/scanner/scanner.cpp
+++ b/scanner/scanner.cpp
@@ -522,6 +522,8 @@ struct interface_t : public element_t
        << std::endl
        << "  static const std::string interface_name;" << std::endl
        << std::endl
+       << "  static const uint32_t interface_version;" << std::endl
+       << std::endl
        << "  operator " << orig_name << "*() const;" << std::endl
        << std::endl;
 
@@ -576,6 +578,8 @@ struct interface_t : public element_t
        << "  " << name << "_t(const resource_t &resource);" << std::endl
        << std::endl
        << "  static const std::string interface_name;" << std::endl
+       << std::endl
+       << "  static const uint32_t interface_version;" << std::endl
        << std::endl
        << "  operator " << orig_name << "*() const;" << std::endl
        << std::endl;
@@ -655,6 +659,8 @@ struct interface_t : public element_t
        << std::endl
        << "const std::string " << name << "_t::interface_name = \"" << orig_name << "\";" << std::endl
        << std::endl
+       << "const uint32_t " << name << "_t::interface_version = static_cast<uint32_t>(" << name << "_interface.version);" << std::endl
+       << std::endl
        << name << "_t::operator " << orig_name << "*() const" << std::endl
        << "{" << std::endl
        << "  return reinterpret_cast<" << orig_name << "*> (c_ptr());" << std::endl
@@ -710,6 +716,8 @@ struct interface_t : public element_t
        << "}" << std::endl
        << std::endl
        << "const std::string " << name << "_t::interface_name = \"" << orig_name << "\";" << std::endl
+       << std::endl
+       << "const uint32_t " << name << "_t::interface_version = static_cast<uint32_t>(" << name << "_interface.version);" << std::endl
        << std::endl
        << name << "_t::operator " << orig_name << "*() const" << std::endl
        << "{" << std::endl


### PR DESCRIPTION
I had some instabilities when I run a simple wayland client using waylandpp libraries on several platforms with different desktop environments. I am not sure if it is related but when compiled interface version (such as wl_output) is greater than the one used by the compositor at run-time, I had sometimes an exception that rises up.

This patch does not fix any problem but it allows me to target with more accuracy static and dynamic version currently in use.

Related to this issue: https://github.com/NilsBrause/waylandpp/issues/77

