### PR TITLE
[cmake] fix quoting of semicolon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ if(BUILD_LIBRARIES)
     add_library(${install_namespace}::${TARGET} ALIAS ${TARGET})
     get_target_property(libtype "${TARGET}" TYPE)
     target_include_directories("${TARGET}" PUBLIC
-      $<BUILD_INTERFACE:include;${CMAKE_CURRENT_BINARY_DIR}> # latter for wayland-version.hpp
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_BINARY_DIR}>" # latter for wayland-version.hpp
       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
       )
     target_compile_options("${TARGET}" PUBLIC ${CFLAGS})


### PR DESCRIPTION
The semicolon causes argument splitting when it is not quoted. That was also hiding the fact that the include path was not correct.

Ref https://gitlab.alpinelinux.org/alpine/aports/-/issues/16239, https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/68210