### PR TITLE
Add missing cstdint include for GCC 14

### DIFF
--- a/include/wayland-server.hpp
+++ b/include/wayland-server.hpp
@@ -27,6 +27,7 @@
 #define WAYLAND_SERVER_HPP
 
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <list>
 #include <memory>


### PR DESCRIPTION
With GCC 14.2.0:

```
build/wayland-server-protocol.hpp:186:25: error: ‘uint32_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
  186 |   static constexpr std::uint32_t global_since_version = 1;
      |                         ^~~~~~~~
      |                         wint_t```
```

With this patch: compiles cleanly