### PR TITLE
Support for PLASMA protocols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ cmake_dependent_option(BUILD_EXAMPLES
   "whether to build the examples (requires BUILD_LIBRARIES to be ON)" OFF
   "BUILD_LIBRARIES" OFF)
 option(BUILD_SERVER "whether to build the server bindings." ON)
+# To activate the following option, it is necessary to deactivate option INSTALL_EXPERIMENTAL_PROTOCOLS and activate option USE_SYSTEM_PROTOCOLS.
+cmake_dependent_option(INSTALL_PLASMA_PROTOCOLS "whether to build the library based on the plasma protocols" OFF
+  USE_SYSTEM_PROTOCOLS OFF)
 
 # Do not report undefined references in libraries, since the protocol libraries cannot be used on their own.
 if(CMAKE_SHARED_LINKER_FLAGS)
@@ -139,6 +142,10 @@ if(BUILD_LIBRARIES)
       endif()
     endif()
   endif()
+  if(INSTALL_PLASMA_PROTOCOLS)
+    find_package(PlasmaWaylandProtocols REQUIRED)
+    message(STATUS "Use [plasma-wayland-protocols] protocols found at ${PLASMA_WAYLAND_PROTOCOLS_DIR}")
+  endif()
 
   # generate protocol source/headers from protocol XMLs
   if(USE_SYSTEM_PROTOCOLS)
@@ -162,6 +169,15 @@ if(BUILD_LIBRARIES)
     file(GLOB PROTO_XMLS_UNSTABLE "${CMAKE_CURRENT_SOURCE_DIR}/protocols/unstable/*.xml")
     file(GLOB PROTO_XMLS_STAGING "${CMAKE_CURRENT_SOURCE_DIR}/protocols/staging/*.xml")
     file(GLOB PROTO_XMLS_EXPERIMENTAL "${CMAKE_CURRENT_SOURCE_DIR}/protocols/experimental/*.xml")
+  endif()
+
+  if(INSTALL_PLASMA_PROTOCOLS)
+    file(GLOB _PROTO_XMLS_PLASMA "${PLASMA_WAYLAND_PROTOCOLS_DIR}/*.xml")
+    # conflicts with plasma-virtual-desktop.xml
+    list(FILTER _PROTO_XMLS_PLASMA EXCLUDE REGEX "org-kde-plasma-virtual-desktop.xml")
+    # conflicts with screencast.xml
+    list(FILTER _PROTO_XMLS_PLASMA EXCLUDE REGEX "zkde-screencast-unstable-v1.xml")
+    filter_out_older_versions("${_PROTO_XMLS_PLASMA}" "${_unique_interface_list}" PROTO_XMLS_PLASMA _unique_interface_list)
   endif()
 
   include(build_client_libraries)
@@ -197,6 +213,12 @@ if(BUILD_LIBRARIES)
 	  list(APPEND INSTALL_TARGETS wayland-client-experimental++)
     if(BUILD_SERVER)
 	    list(APPEND INSTALL_TARGETS wayland-server-experimental++)
+    endif()
+  endif()
+  if(INSTALL_PLASMA_PROTOCOLS)
+    list(APPEND INSTALL_TARGETS wayland-client-plasma++)
+    if(BUILD_SERVER)
+      list(APPEND INSTALL_TARGETS wayland-server-plasma++)
     endif()
   endif()
   install(TARGETS ${INSTALL_TARGETS} EXPORT ${CMAKE_PROJECT_NAME}-targets
@@ -250,6 +272,9 @@ if(BUILD_DOCUMENTATION)
   endif()
   if (INSTALL_EXPERIMENTAL_PROTOCOLS)
     set(DOCUMENTATION_DEPENDENCIES ${DOCUMENTATION_DEPENDENCIES} ${PROTO_FILES_EXPERIMENTAL})
+  endif()
+  if (INSTALL_PLASMA_PROTOCOLS)
+    set(DOCUMENTATION_DEPENDENCIES ${DOCUMENTATION_DEPENDENCIES} ${PROTO_FILES_PLASMA})
   endif()
 
   add_custom_command(

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ CMake Variable                   | Effect                                       
 `INSTALL_UNSTABLE_PROTOCOLS`     | Whether to install the unstable protocols                    | ON
 `INSTALL_STAGING_PROTOCOLS`      | Whether to install the staging protocols                     | ON
 `INSTALL_EXPERIMENTAL_PROTOCOLS` | Whether to install the experimental protocols                | ON
+`INSTALL_PLASMA_PROTOCOLS`       | Whether to install the plasma protocols                      | OFF
 `USE_SYSTEM_PROTOCOLS`           | Whether to use system protocols instead of bundled protocols | OFF
 
 Notes:

--- a/cmake/build_client_libraries.cmake
+++ b/cmake/build_client_libraries.cmake
@@ -108,3 +108,20 @@ define_library(wayland-cursor++
   src/wayland-cursor.cpp
   wayland-client-protocol.hpp)
 target_link_libraries(wayland-cursor++ INTERFACE wayland-client++)
+
+if(INSTALL_PLASMA_PROTOCOLS)
+  set(PROTO_FILES_PLASMA
+    "wayland-client-protocol-plasma.hpp"
+    "wayland-client-protocol-plasma.cpp")
+  generate_cpp_client_files("${PROTO_XMLS_PLASMA}" "${PROTO_FILES_PLASMA}" "-x;wayland-client-protocol.hpp" "")
+  set(WAYLAND_CLIENT_PLASMA_HEADERS
+    "${CMAKE_CURRENT_BINARY_DIR}/wayland-client-protocol-plasma.hpp")
+define_library(wayland-client-plasma++
+  "${WAYLAND_CLIENT_CFLAGS}"
+  "${WAYLAND_CLIENT_LIBRARIES}"
+  "${WAYLAND_CLIENT_PLASMA_HEADERS}"
+  wayland-client-protocol-plasma.cpp
+  wayland-client-protocol-plasma.hpp
+  wayland-client-protocol.hpp)
+  target_link_libraries(wayland-client-plasma++ INTERFACE wayland-client++)
+endif()

--- a/cmake/build_server_libraries.cmake
+++ b/cmake/build_server_libraries.cmake
@@ -87,3 +87,20 @@ if(INSTALL_EXPERIMENTAL_PROTOCOLS)
     wayland-server-protocol-experimental.hpp
     wayland-server-protocol.hpp)
 endif()
+
+if(INSTALL_PLASMA_PROTOCOLS)
+  set(PROTO_FILES_PLASMA
+    "wayland-server-protocol-plasma.hpp"
+    "wayland-server-protocol-plasma.cpp")
+  generate_cpp_server_files("${PROTO_XMLS_PLASMA}" "${PROTO_FILES_PLASMA}" "-x;wayland-server-protocol.hpp" "")
+  set(WAYLAND_SERVER_PLASMA_HEADERS
+    "${CMAKE_CURRENT_BINARY_DIR}/wayland-server-protocol-plasma.hpp")
+  define_library(wayland-server-plasma++
+    "${WAYLAND_SERVER_CFLAGS}"
+    "${WAYLAND_SERVER_LIBRARIES}"
+    "${WAYLAND_SERVER_PLASMA_HEADERS}"
+    wayland-server-protocol-plasma.cpp
+    wayland-server-protocol-plasma.hpp
+    wayland-server-protocol.hpp)
+  target_link_libraries(wayland-server-plasma++ INTERFACE wayland-server++)
+endif()

--- a/wayland-client-plasma++.pc.in
+++ b/wayland-client-plasma++.pc.in
@@ -1,0 +1,37 @@
+# Copyright (c) 2025 Nils Christopher Brause
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+prefix=@prefix@
+exec_prefix=${prefix}
+datarootdir=@datarootdir@
+pkgdatadir=@pkgdatadir@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: Wayland C++ Client Plasma
+Description: Wayland C++ client side library plasma protocols
+Version: @PROJECT_VERSION@
+URL: https://github.com/NilsBrause/waylandpp
+Requires: wayland-client++
+Cflags: -I${includedir}
+Libs: -L${libdir} -lwayland-client-plasma++

--- a/wayland-server-plasma++.pc.in
+++ b/wayland-server-plasma++.pc.in
@@ -1,0 +1,37 @@
+# Copyright (c) 2025 Nils Christopher Brause
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+prefix=@prefix@
+exec_prefix=${prefix}
+datarootdir=@datarootdir@
+pkgdatadir=@pkgdatadir@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: Wayland C++ Server Plasma
+Description: Wayland C++ server side library plasma protocols
+Version: @PROJECT_VERSION@
+URL: https://github.com/NilsBrause/waylandpp
+Requires: wayland-server++
+Cflags: -I${includedir}
+Libs: -L${libdir} -lwayland-server-plasma++


### PR DESCRIPTION
Available only if option USE_SYSTEM_PROTOCOLS is enabled and option INSTALL_EXPERIMENTAL_PROTOCOLS is disabled. We suggest to build libraries which are able to communicate with extended interfaces of the KWIN compositor.

What motivates me about these protocols is the possibility of retrieving the EDID for each of my screens.