### PR TITLE
Support for WLROOTS protocols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ cmake_dependent_option(BUILD_EXAMPLES
   "whether to build the examples (requires BUILD_LIBRARIES to be ON)" OFF
   "BUILD_LIBRARIES" OFF)
 option(BUILD_SERVER "whether to build the server bindings." ON)
+# To activate the following option, it is necessary to deactivate option INSTALL_EXPERIMENTAL_PROTOCOLS and activate option USE_SYSTEM_PROTOCOLS.
+cmake_dependent_option(INSTALL_WLR_PROTOCOLS "whether to build the library based on the wlr protocols" OFF
+  USE_SYSTEM_PROTOCOLS OFF)
 
 # Do not report undefined references in libraries, since the protocol libraries cannot be used on their own.
 if(CMAKE_SHARED_LINKER_FLAGS)
@@ -139,6 +142,11 @@ if(BUILD_LIBRARIES)
       endif()
     endif()
   endif()
+  if(INSTALL_WLR_PROTOCOLS)
+    pkg_check_modules(WLR_PROTOCOLS REQUIRED wlr-protocols)
+    pkg_get_variable(WLR_PROTOCOLS_PKGDATADIR wlr-protocols pkgdatadir)
+    message(STATUS "Use [wlr-protocols] protocols found at ${WLR_PROTOCOLS_PKGDATADIR}")
+  endif()
 
   # generate protocol source/headers from protocol XMLs
   if(USE_SYSTEM_PROTOCOLS)
@@ -162,6 +170,10 @@ if(BUILD_LIBRARIES)
     file(GLOB PROTO_XMLS_UNSTABLE "${CMAKE_CURRENT_SOURCE_DIR}/protocols/unstable/*.xml")
     file(GLOB PROTO_XMLS_STAGING "${CMAKE_CURRENT_SOURCE_DIR}/protocols/staging/*.xml")
     file(GLOB PROTO_XMLS_EXPERIMENTAL "${CMAKE_CURRENT_SOURCE_DIR}/protocols/experimental/*.xml")
+  endif()
+  if(INSTALL_WLR_PROTOCOLS)
+    file(GLOB _PROTO_XMLS_WLR "${WLR_PROTOCOLS_PKGDATADIR}/**/*.xml")
+    filter_out_older_versions("${_PROTO_XMLS_WLR}" "${_unique_interface_list}" PROTO_XMLS_WLR _unique_interface_list)
   endif()
 
   include(build_client_libraries)
@@ -197,6 +209,12 @@ if(BUILD_LIBRARIES)
 	  list(APPEND INSTALL_TARGETS wayland-client-experimental++)
     if(BUILD_SERVER)
 	    list(APPEND INSTALL_TARGETS wayland-server-experimental++)
+    endif()
+  endif()
+  if(INSTALL_WLR_PROTOCOLS)
+    list(APPEND INSTALL_TARGETS wayland-client-wlr++)
+    if(BUILD_SERVER)
+      list(APPEND INSTALL_TARGETS wayland-server-wlr++)
     endif()
   endif()
   install(TARGETS ${INSTALL_TARGETS} EXPORT ${CMAKE_PROJECT_NAME}-targets
@@ -250,6 +268,9 @@ if(BUILD_DOCUMENTATION)
   endif()
   if (INSTALL_EXPERIMENTAL_PROTOCOLS)
     set(DOCUMENTATION_DEPENDENCIES ${DOCUMENTATION_DEPENDENCIES} ${PROTO_FILES_EXPERIMENTAL})
+  endif()
+  if (INSTALL_WLR_PROTOCOLS)
+    set(DOCUMENTATION_DEPENDENCIES ${DOCUMENTATION_DEPENDENCIES} ${PROTO_FILES_WLR})
   endif()
 
   add_custom_command(

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ CMake Variable                   | Effect                                       
 `INSTALL_STAGING_PROTOCOLS`      | Whether to install the staging protocols                     | ON
 `INSTALL_EXPERIMENTAL_PROTOCOLS` | Whether to install the experimental protocols                | ON
 `USE_SYSTEM_PROTOCOLS`           | Whether to use system protocols instead of bundled protocols | OFF
+`INSTALL_WLR_PROTOCOLS`          | Whether to install the wlr protocols                         | OFF
 
 Notes:
 - When using the system protocols, the experimental protocols cannot be installed.

--- a/cmake/build_client_libraries.cmake
+++ b/cmake/build_client_libraries.cmake
@@ -108,3 +108,21 @@ define_library(wayland-cursor++
   src/wayland-cursor.cpp
   wayland-client-protocol.hpp)
 target_link_libraries(wayland-cursor++ INTERFACE wayland-client++)
+
+if(INSTALL_WLR_PROTOCOLS)
+  set(PROTO_FILES_WLR
+    "wayland-client-protocol-wlr.hpp"
+    "wayland-client-protocol-wlr.cpp")
+  generate_cpp_client_files("${PROTO_XMLS_WLR}" "${PROTO_FILES_WLR}" "-x;wayland-client-protocol-extra.hpp" "")
+  set(WAYLAND_CLIENT_WLR_HEADERS
+    "${CMAKE_CURRENT_BINARY_DIR}/wayland-client-protocol-extra.hpp"
+    "${CMAKE_CURRENT_BINARY_DIR}/wayland-client-protocol-wlr.hpp")
+  define_library(wayland-client-wlr++
+    "${WAYLAND_CLIENT_CFLAGS}"
+    "${WAYLAND_CLIENT_LIBRARIES};wayland-client-extra++"
+    "${WAYLAND_CLIENT_WLR_HEADERS}"
+    wayland-client-protocol-wlr.cpp 
+    wayland-client-protocol-wlr.hpp
+    wayland-client-protocol.hpp)
+  target_link_libraries(wayland-client-wlr++ INTERFACE wayland-client-extra++)
+endif()

--- a/cmake/build_server_libraries.cmake
+++ b/cmake/build_server_libraries.cmake
@@ -87,3 +87,20 @@ if(INSTALL_EXPERIMENTAL_PROTOCOLS)
     wayland-server-protocol-experimental.hpp
     wayland-server-protocol.hpp)
 endif()
+
+if(INSTALL_WLR_PROTOCOLS)
+  set(PROTO_FILES_WLR
+    "wayland-server-protocol-wlr.hpp"
+    "wayland-server-protocol-wlr.cpp")
+  generate_cpp_server_files("${PROTO_XMLS_WLR}" "${PROTO_FILES_WLR}" "-x;wayland-server-protocol-extra.hpp" "")
+  set(WAYLAND_SERVER_WLR_HEADERS
+    "${CMAKE_CURRENT_BINARY_DIR}/wayland-server-protocol-wlr.hpp")
+  define_library(wayland-server-wlr++
+    "${WAYLAND_SERVER_CFLAGS}"
+    "${WAYLAND_SERVER_LIBRARIES}"
+    "${WAYLAND_SERVER_WLR_HEADERS}"
+    wayland-server-protocol-wlr.cpp
+    wayland-server-protocol-wlr.hpp
+    wayland-server-protocol.hpp)
+  target_link_libraries(wayland-server-wlr++ INTERFACE wayland-server-extra++)
+endif()

--- a/wayland-client-wlr++.pc.in
+++ b/wayland-client-wlr++.pc.in
@@ -1,0 +1,37 @@
+# Copyright (c) 2025 Nils Christopher Brause
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+prefix=@prefix@
+exec_prefix=${prefix}
+datarootdir=@datarootdir@
+pkgdatadir=@pkgdatadir@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: Wayland C++ Client wlroots
+Description: Wayland C++ client side library wlr protocols
+Version: @PROJECT_VERSION@
+URL: https://github.com/NilsBrause/waylandpp
+Requires: wayland-client++ wayland-client-extra++
+Cflags: -I${includedir}
+Libs: -L${libdir} -lwayland-client-wlr++

--- a/wayland-server-wlr++.pc.in
+++ b/wayland-server-wlr++.pc.in
@@ -1,0 +1,37 @@
+# Copyright (c) 2025 Nils Christopher Brause
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+prefix=@prefix@
+exec_prefix=${prefix}
+datarootdir=@datarootdir@
+pkgdatadir=@pkgdatadir@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: Wayland C++ Server wlroots
+Description: Wayland C++ server side library wlr protocols
+Version: @PROJECT_VERSION@
+URL: https://github.com/NilsBrause/waylandpp
+Requires: wayland-server++ wayland-server-extra++
+Cflags: -I${includedir}
+Libs: -L${libdir} -lwayland-server-wlr++


### PR DESCRIPTION
Suggest to build libraries which are able to communicate with extended interfaces of the wlroots based compositors.

Commands to build and install wlroots protocols
```
git clone https://gitlab.freedesktop.org/wlroots/wlr-protocols.git
cd wlr-protocols
make
make install
make install-pc
```

Command cmake to run to build waylandpp with wlroots protocols (from build directory):
```
PKG_CONFIG_PATH=/usr/share/pkgconfig:$PKG_CONFIG_PATH  cmake .. -DBUILD_DOCUMENTATION=OFF -DINSTALL_EXPERIMENTAL_PROTOCOLS=OFF -DUSE_SYSTEM_PROTOCOLS=ON -DINSTALL_WLR_PROTOCOLS=On
```